### PR TITLE
feat(): support for chart values with custom topology configuration

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -8,7 +8,7 @@ import (
 	// "github.com/spf13/cobra/doc"
 )
 
-var version = "0.4.2"
+var version = "0.4.3"
 var rootCmd = &cobra.Command{
 	Use:     "kubeslice-cli",
 	Version: version,

--- a/doc/kubeslice-cli_install.md
+++ b/doc/kubeslice-cli_install.md
@@ -36,7 +36,7 @@ kubeslice-cli install [flags]
                          	- worker-registration: Skips the registration of KubeSlice Workers on the Controller
                          	- worker: Skips the installation of KubeSlice Worker
                          	- demo: Skips the installation of additional example applications
-							- ui: Skips the installtion of enterprise UI components (Kubeslice-Manager)
+				- ui: Skips the installtion of enterprise UI components (Kubeslice-Manager)
 ```
 
 ### Options inherited from parent commands

--- a/pkg/internal/bootstrap-configuration.go
+++ b/pkg/internal/bootstrap-configuration.go
@@ -25,6 +25,8 @@ type HelmChartConfiguration struct {
 type HelmChart struct {
 	ChartName string `yaml:"chart_name"`
 	Version   string `yaml:"version"`
+	// Values to be passed as --set arguments to helm install
+	Values map[string]string `yaml:"values"`
 }
 
 type KubeSliceConfiguration struct {
@@ -36,7 +38,7 @@ type ClusterConfiguration struct {
 	KubeConfigPath    string    `yaml:"kube_config_path"`
 	ControllerCluster Cluster   `yaml:"controller"`
 	WorkerClusters    []Cluster `yaml:"workers"`
-	ClusterType       string    `yaml:"cluster"`
+	ClusterType       string    `yaml:"cluster_type"`
 }
 
 type Cluster struct {

--- a/pkg/internal/controller.go
+++ b/pkg/internal/controller.go
@@ -26,7 +26,7 @@ func InstallKubeSliceController(ApplicationConfiguration *ConfigurationSpecs) {
 
 	cc := ApplicationConfiguration.Configuration.ClusterConfiguration
 	hc := ApplicationConfiguration.Configuration.HelmChartConfiguration
-	generateControllerValuesFile(cc.ControllerCluster, ApplicationConfiguration.Configuration.HelmChartConfiguration.ImagePullSecret)
+	generateControllerValuesFile(cc.ControllerCluster, ApplicationConfiguration.Configuration.HelmChartConfiguration)
 	util.Printf("%s Generated Helm Values file for Controller Installation %s", util.Tick, controllerValuesFileName)
 	time.Sleep(200 * time.Millisecond)
 
@@ -52,9 +52,11 @@ func UninstallKubeSliceController(ApplicationConfiguration *ConfigurationSpecs) 
 	// util.Printf("%s Waiting for KubeSlice Manager Pods to be removed...", util.Wait)
 }
 
-func generateControllerValuesFile(cluster Cluster, imagePullSecret ImagePullSecrets) {
-
-	util.DumpFile(fmt.Sprintf(controllerValuesTemplate+generateImagePullSecretsValue(imagePullSecret), cluster.ControlPlaneAddress), kubesliceDirectory+"/"+controllerValuesFileName)
+func generateControllerValuesFile(cluster Cluster, hcConfig HelmChartConfiguration) {
+	err := generateValuesFile(kubesliceDirectory+"/"+controllerValuesFileName, &hcConfig.ControllerChart, fmt.Sprintf(controllerValuesTemplate+generateImagePullSecretsValue(hcConfig.ImagePullSecret), cluster.ControlPlaneAddress))
+	if err != nil {
+		log.Fatalf("%s %s", util.Cross, err)
+	}
 }
 
 func installKubeSliceController(cluster Cluster, hc HelmChartConfiguration) {

--- a/pkg/internal/get-network-info.go
+++ b/pkg/internal/get-network-info.go
@@ -13,7 +13,7 @@ import (
 func GatherNetworkInformation(ApplicationConfiguration *ConfigurationSpecs) {
 	util.Printf("\nFetching Network Address for Clusters...")
 
-	if ApplicationConfiguration.Configuration.ClusterConfiguration.Profile == "" {
+	if ApplicationConfiguration.Configuration.ClusterConfiguration.Profile == "" && ApplicationConfiguration.Configuration.ClusterConfiguration.ClusterType != "kind" {
 		setControlPlaneAddress(&ApplicationConfiguration.Configuration.ClusterConfiguration)
 		setNodeIP(&ApplicationConfiguration.Configuration.ClusterConfiguration)
 	} else {

--- a/pkg/internal/values.go
+++ b/pkg/internal/values.go
@@ -1,0 +1,61 @@
+package internal
+
+import (
+	"fmt"
+	"io/ioutil"
+	"strings"
+
+	"gopkg.in/yaml.v2"
+)
+
+func mergeMaps(dest, src map[interface{}]interface{}) map[interface{}]interface{} {
+	for k, v := range src {
+		if d, ok := dest[k]; ok {
+			switch d.(type) {
+			case map[interface{}]interface{}:
+				dest[k] = mergeMaps(d.(map[interface{}]interface{}), v.(map[interface{}]interface{}))
+			default:
+				dest[k] = v
+			}
+		} else {
+			dest[k] = v
+		}
+	}
+	return dest
+}
+
+func generateValuesFile(filePath string, hc *HelmChart, defaults string) error {
+	valuesMap := make(map[interface{}]interface{})
+	for k, v := range hc.Values {
+		keys := strings.Split(k, ".")
+		currentMap := valuesMap
+		for i, key := range keys {
+			if i == len(keys)-1 {
+				currentMap[key] = v
+			} else {
+				if currentMap[key] == nil {
+					currentMap[key] = make(map[interface{}]interface{})
+				}
+				currentMap = currentMap[key].(map[interface{}]interface{})
+			}
+		}
+	}
+
+	defaultsMap := make(map[interface{}]interface{})
+	if err := yaml.Unmarshal([]byte(defaults), &defaultsMap); err != nil {
+		return fmt.Errorf("error parsing defaults: %v", err)
+	}
+
+	mergedMap := mergeMaps(valuesMap, defaultsMap)
+
+	finalData, err := yaml.Marshal(mergedMap)
+	if err != nil {
+		return fmt.Errorf("error encoding final data as YAML: %v", err)
+	}
+
+	if err := ioutil.WriteFile(filePath, finalData, 0644); err != nil {
+		return fmt.Errorf("error writing values file: %v", err)
+	}
+
+	return nil
+}

--- a/pkg/internal/verify-executables.go
+++ b/pkg/internal/verify-executables.go
@@ -14,7 +14,7 @@ import (
 func VerifyExecutables(ApplicationConfiguration *ConfigurationSpecs) {
 	util.Printf("Verifying Executables...")
 	time.Sleep(200 * time.Millisecond)
-	if ApplicationConfiguration.Configuration.ClusterConfiguration.Profile != "" {
+	if ApplicationConfiguration.Configuration.ClusterConfiguration.Profile != "" || ApplicationConfiguration.Configuration.ClusterConfiguration.ClusterType == "kind" {
 		util.ExecutablePaths = map[string]string{
 			"kind":    "kind",
 			"kubectl": "kubectl",

--- a/pkg/slicectl.go
+++ b/pkg/slicectl.go
@@ -62,9 +62,9 @@ func basicInstall(skipSteps map[string]string) {
 		if !skipKind {
 			internal.CreateKindClusters(ApplicationConfiguration)
 		}
-		if !skipCalico {
-			internal.InstallCalico(&ApplicationConfiguration.Configuration.ClusterConfiguration)
-		}
+	}
+	if (ApplicationConfiguration.Configuration.ClusterConfiguration.Profile != "" || ApplicationConfiguration.Configuration.ClusterConfiguration.ClusterType == "kind") && !skipCalico {
+		internal.InstallCalico(&ApplicationConfiguration.Configuration.ClusterConfiguration)
 	}
 	internal.GatherNetworkInformation(ApplicationConfiguration)
 	internal.AddHelmCharts(ApplicationConfiguration)

--- a/samples/template.yaml
+++ b/samples/template.yaml
@@ -2,6 +2,7 @@ configuration:
   cluster_configuration:
     profile: #{the KubeSlice Profile for the demo. Possible values [full-demo, minimal-demo]}
     kube_config_path: #{specify the kube config file to use for topology setup; for topology only}
+    cluster_type: #{optional: specify the type of cluster. Valid values are kind, cloud, data-center}
     controller:
       name: #{the user defined name of the controller cluster}
       context_name: #{the name of the context to use from kubeconfig file; for topology only}
@@ -39,12 +40,15 @@ configuration:
     controller_chart:
       chart_name: #{The name of the Controller Chart}
       version: #{The version of the chart to use. Leave blank for latest version}
+      values: #(Values to be passed as --set arguments to helm install)
     worker_chart:
       chart_name: #{The name of the Worker Chart}
       version: #{The version of the chart to use. Leave blank for latest version}
+      values: #(Values to be passed as --set arguments to helm install)
     ui_chart:
       chart_name: #{The name of the UI/Enterprise Chart}
       version: #{The version of the chart to use. Leave blank for latest version}
+      values: #(Values to be passed as --set arguments to helm install)
     helm_username: #{Helm Username if the repo is private}
     helm_password: #{Helm Password if the repo is private}
     image_pull_secret: #{The image pull secrets. Optional for OpenSource, required for enterprise}

--- a/util/print-util.go
+++ b/util/print-util.go
@@ -9,7 +9,8 @@ const (
 	Cross = string(rune(0x274c))
 	Tick  = string(rune(0x2714))
 	Wait  = string(rune(0x267B))
-	Run  = string(rune(0x1F3C3))
+	Run   = string(rune(0x1F3C3))
+	Warn  = string(rune(0x26A0))
 )
 
 func Printf(format string, a ...interface{}) {


### PR DESCRIPTION
# Description
- Added support to provide chart values along with custom topology configuration
- Additional support for kind clusters when using custom topology

Fixes :
 - Install fails with error deploying Metrics server
 - should deploy nodeport service (instead of LB service) and port-forward it
 - Message needs to be updated when skipping UI installation 
 
## How Has This Been Tested?

- [x] Manual testing



## Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] Does this PR requires documentation updates?
* [x] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code.
* [x] I have commented my code, particularly in hard-to-understand areas.
* [x] I have tested it for all user roles.
* [ ] I have added all the required unit test cases.

## Does this PR introduce a breaking change?
<!--
If NO, leave the release-note block blank.
If YES, a release note is required:
Enter your extended release note in the block below. If the PR requires additional manual action from users switching to the new version, include the string "action-required".
-->

```release-note

```

