### PR TITLE
feat(#39): added flags

### DIFF
--- a/cmd/install.go
+++ b/cmd/install.go
@@ -6,6 +6,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var withCertManager bool
+
 var installCmd = &cobra.Command{
 	Use:     "install",
 	Aliases: []string{"i"},
@@ -37,6 +39,10 @@ var installCmd = &cobra.Command{
 		} else {
 			pkg.ReadAndValidateConfiguration(Config)
 		}
+		// Default behaviour is not ot install cert-manager
+		if !withCertManager {
+			skipSteps = append(skipSteps, "cert-manager")
+		}
 		stepsToSkipMap := mapFromSlice(skipSteps)
 		pkg.Install(stepsToSkipMap)
 	},
@@ -65,5 +71,7 @@ Supported values:
 	- worker: Skips the installation of KubeSlice Worker
 	- demo: Skips the installation of additional example applications
 	- ui: Skips the installtion of enterprise UI components (Kubeslice-Manager)`)
+	// TODO: update the controller version after release
+	installCmd.Flags().BoolVarP(&withCertManager, "with-cert-manager", "", false, `Installs Cert-Manager for kubeslice controller (for versions < 0.7.0)`)
 
 }

--- a/cmd/uninstall.go
+++ b/cmd/uninstall.go
@@ -10,6 +10,7 @@ var (
 	uninstallAll          bool
 	uninstallController   bool
 	uninstallUI           bool
+	uninstallCertManager  bool
 	uninstallWorker       = []string{}
 	workersToUninstall    map[string]string
 	componentsToUninstall map[string]string
@@ -46,11 +47,13 @@ var uninstallCmd = &cobra.Command{
 		if uninstallUI {
 			componentsToUninstall["ui"] = ""
 		}
+		if uninstallCertManager {
+			componentsToUninstall["cert-manager"] = ""
+		}
 		if len(uninstallWorker) > 0 {
 			componentsToUninstall["worker"] = ""
 			workersToUninstall = mapFromSlice(uninstallWorker)
 		}
-
 		pkg.Uninstall(componentsToUninstall, workersToUninstall)
 	},
 }
@@ -59,6 +62,8 @@ func init() {
 	rootCmd.AddCommand(uninstallCmd)
 	uninstallCmd.Flags().BoolVarP(&uninstallAll, "all", "a", false, `Uninstalls all components (Worker, Controller, UI)`)
 	uninstallCmd.Flags().BoolVarP(&uninstallUI, "ui", "u", false, `Uninstalls enterprise UI components (Kubeslice-Manager)`)
+	// TODO: update the controller version after release
+	uninstallCmd.Flags().BoolVarP(&uninstallCertManager, "cert-manager", "", false, `Uninstalls Cert Manager (required for controller version < 0.7.0)`)
 	// TODO: A discussion is needed for graceful cleanup of worker clusters
 	// uninstallCmd.Flags().StringSliceVarP(&uninstallWorker, "worker", "", []string{}, `Uninstalls worker clusters`)
 	// uninstallCmd.Flags().Lookup("worker").NoOptDefVal = "*"

--- a/pkg/internal/constants.go
+++ b/pkg/internal/constants.go
@@ -14,6 +14,7 @@ const (
 	UI_install_Component          = "ui"
 	Worker_Component              = "worker"
 	Demo_Component                = "demo"
+	CertManager_Component         = "cert-manager"
 	SecretObject                  = "secrets"
 	OutputFormatYaml              = "yaml"
 	OutputFormatJson              = "json"

--- a/pkg/slicectl.go
+++ b/pkg/slicectl.go
@@ -51,6 +51,7 @@ func basicInstall(skipSteps map[string]string) {
 	_, skipWorker := skipSteps[internal.Worker_Component]
 	_, skipWorker_registration := skipSteps[internal.Worker_registration_Component]
 	_, skipUI := skipSteps[internal.UI_install_Component]
+	_, skipCertManager := skipSteps[internal.CertManager_Component]
 
 	internal.GenerateKubeSliceDirectory()
 	if ApplicationConfiguration.Configuration.ClusterConfiguration.Profile != "" {
@@ -69,7 +70,9 @@ func basicInstall(skipSteps map[string]string) {
 	internal.GatherNetworkInformation(ApplicationConfiguration)
 	internal.AddHelmCharts(ApplicationConfiguration)
 	if !skipController {
-		internal.InstallCertManager(ApplicationConfiguration)
+		if !skipCertManager {
+			internal.InstallCertManager(ApplicationConfiguration)
+		}
 		internal.InstallKubeSliceController(ApplicationConfiguration)
 		internal.CreateKubeSliceProject(ApplicationConfiguration, nil)
 	}
@@ -91,6 +94,7 @@ func Uninstall(componentsToUninstall, workersToUninstall map[string]string) {
 	// Custom topology passed
 	if ApplicationConfiguration.Configuration.ClusterConfiguration.Profile == "" {
 		_, uninstallController := componentsToUninstall[internal.Controller_Component]
+		_, uninstallCertManager := componentsToUninstall[internal.CertManager_Component]
 		_, uninstallWorker := componentsToUninstall[internal.Worker_Component]
 		_, uninstallUI := componentsToUninstall[internal.UI_install_Component]
 
@@ -102,7 +106,9 @@ func Uninstall(componentsToUninstall, workersToUninstall map[string]string) {
 		}
 		if uninstallController {
 			internal.UninstallKubeSliceController(ApplicationConfiguration)
-			internal.UninstallCertManager(ApplicationConfiguration)
+			if uninstallCertManager {
+				internal.UninstallCertManager(ApplicationConfiguration)
+			}
 		}
 		return
 	}


### PR DESCRIPTION
# Description
- Added flags to support cert-manager installation for previous controller versions. The default behaviour is NOT to install or uninstall cert-manager (unless specified)
- - `--with-cert-manager` for install cmd
- - `--cert-manager` for uninstall cmd

Fixes #39 

## How Has This Been Tested?
- [x] Manual testing

## Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] Does this PR requires documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code.
* [x] I have commented my code, particularly in hard-to-understand areas.
* [x] I have tested it for all user roles.
* [x] I have added all the required unit test cases.

## Does this PR introduce a breaking change?
<!--
If NO, leave the release-note block blank.
If YES, a release note is required:
Enter your extended release note in the block below. If the PR requires additional manual action from users switching to the new version, include the string "action-required".
-->

```release-note

```

