### PR TITLE
feat(#34): added option to fetch UI endpoint

### DIFF
--- a/cmd/get.go
+++ b/cmd/get.go
@@ -14,7 +14,7 @@ var getCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		var objectName string
 		ns, _ := cmd.Flags().GetString("namespace")
-		if ns == "" {
+		if ns == "" && args[0] != "ui-endpoint" {
 			util.Fatalf("Namespace is required")
 		}
 		worker, _ := cmd.Flags().GetString("worker")
@@ -34,6 +34,8 @@ var getCmd = &cobra.Command{
 			pkg.GetSecrets(worker)
 		case "worker":
 			pkg.GetWorker()
+		case "ui-endpoint":
+			pkg.GetUIEndpoint()
 		default:
 			util.Fatalf("Invalid object type")
 		}

--- a/pkg/ui.go
+++ b/pkg/ui.go
@@ -1,0 +1,7 @@
+package pkg
+
+import "github.com/kubeslice/kubeslice-cli/pkg/internal"
+
+func GetUIEndpoint() {
+	internal.GetUIEndpoint(CliOptions.Cluster)
+}


### PR DESCRIPTION
# Description

Added option to fetch Kubeslice manager Endpoint
`kubectl get ui-endpoint`

Closes #34 

## How Has This Been Tested?
- [x] Manual testing

## Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] Does this PR requires documentation updates?
* [x] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code.
* [x] I have commented my code, particularly in hard-to-understand areas.
* [x] I have tested it for all user roles.
* [ ] I have added all the required unit test cases.

## Does this PR introduce a breaking change?
<!--
If NO, leave the release-note block blank.
If YES, a release note is required:
Enter your extended release note in the block below. If the PR requires additional manual action from users switching to the new version, include the string "action-required".
-->

```release-note

```

