### PR TITLE
feat(#42): Adding default endpoint for OCI registry

### DIFF
--- a/pkg/internal/helm-repo-add.go
+++ b/pkg/internal/helm-repo-add.go
@@ -57,10 +57,14 @@ func updateHelmChart() {
 func generateImagePullSecretsValue(ImagePullSecret ImagePullSecrets) string {
 	imagePullSecretsValue := ""
 	ips := ImagePullSecret
-	if ips.Registry != "" && ips.Username != "" && ips.Password != "" {
+	if ips.Username != "" && ips.Password != "" {
 		email := ""
 		if ips.Email != "" {
 			email = "email: " + ips.Email
+		}
+		// setting default registry
+		if ips.Registry == "" {
+			ips.Registry = "https://index.docker.io/v1/"
 		}
 		imagePullSecretsValue = fmt.Sprintf(imagePullSecretsTemplate, ips.Registry, ips.Username, ips.Password, email)
 	}

--- a/samples/template.yaml
+++ b/samples/template.yaml
@@ -52,7 +52,7 @@ configuration:
     helm_username: #{Helm Username if the repo is private}
     helm_password: #{Helm Password if the repo is private}
     image_pull_secret: #{The image pull secrets. Optional for OpenSource, required for enterprise}
-      registry: #{The endpoint of the OCI registry to use}
+      registry: #{The endpoint of the OCI registry to use. Default is `https://index.docker.io/v1/`} 
       username: #{The username to authenticate against the OCI registry}
       password: #{The password to authenticate against the OCI registry}
       email: #{The email to authenticate against the OCI registry}


### PR DESCRIPTION


# Description
If a user does not pass the registry endpoint it defaults to `https://index.docker.io/v1/`

Fixes #42 

## How Has This Been Tested?
* [x] Manual testing

## Checklist:

* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR requires documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] I have performed a self-review of my own code.
* [ ] I have commented my code, particularly in hard-to-understand areas.
* [ ] I have tested it for all user roles.
* [ ] I have added all the required unit test cases.

## Does this PR introduce a breaking change?
<!--
If NO, leave the release-note block blank.
If YES, a release note is required:
Enter your extended release note in the block below. If the PR requires additional manual action from users switching to the new version, include the string "action-required".
-->

```release-note

```

