### PR TITLE
feat(): Release 0.5.0

### DIFF
--- a/cmd/get.go
+++ b/cmd/get.go
@@ -14,7 +14,7 @@ var getCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		var objectName string
 		ns, _ := cmd.Flags().GetString("namespace")
-		if ns == "" {
+		if ns == "" && args[0] != "ui-endpoint" {
 			util.Fatalf("Namespace is required")
 		}
 		worker, _ := cmd.Flags().GetString("worker")
@@ -34,6 +34,8 @@ var getCmd = &cobra.Command{
 			pkg.GetSecrets(worker)
 		case "worker":
 			pkg.GetWorker()
+		case "ui-endpoint":
+			pkg.GetUIEndpoint()
 		default:
 			util.Fatalf("Invalid object type")
 		}

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -6,6 +6,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var withCertManager bool
+
 var installCmd = &cobra.Command{
 	Use:     "install",
 	Aliases: []string{"i"},
@@ -37,6 +39,10 @@ var installCmd = &cobra.Command{
 		} else {
 			pkg.ReadAndValidateConfiguration(Config)
 		}
+		// Default behaviour is not ot install cert-manager
+		if !withCertManager {
+			skipSteps = append(skipSteps, "cert-manager")
+		}
 		stepsToSkipMap := mapFromSlice(skipSteps)
 		pkg.Install(stepsToSkipMap)
 	},
@@ -65,5 +71,7 @@ Supported values:
 	- worker: Skips the installation of KubeSlice Worker
 	- demo: Skips the installation of additional example applications
 	- ui: Skips the installtion of enterprise UI components (Kubeslice-Manager)`)
+	// TODO: update the controller version after release
+	installCmd.Flags().BoolVarP(&withCertManager, "with-cert-manager", "", false, `Installs Cert-Manager for kubeslice controller (for versions < 0.7.0)`)
 
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -8,7 +8,7 @@ import (
 	// "github.com/spf13/cobra/doc"
 )
 
-var version = "0.4.4"
+var version = "0.5.0"
 var rootCmd = &cobra.Command{
 	Use:     "kubeslice-cli",
 	Version: version,

--- a/cmd/uninstall.go
+++ b/cmd/uninstall.go
@@ -10,6 +10,7 @@ var (
 	uninstallAll          bool
 	uninstallController   bool
 	uninstallUI           bool
+	uninstallCertManager  bool
 	uninstallWorker       = []string{}
 	workersToUninstall    map[string]string
 	componentsToUninstall map[string]string
@@ -46,11 +47,13 @@ var uninstallCmd = &cobra.Command{
 		if uninstallUI {
 			componentsToUninstall["ui"] = ""
 		}
+		if uninstallCertManager {
+			componentsToUninstall["cert-manager"] = ""
+		}
 		if len(uninstallWorker) > 0 {
 			componentsToUninstall["worker"] = ""
 			workersToUninstall = mapFromSlice(uninstallWorker)
 		}
-
 		pkg.Uninstall(componentsToUninstall, workersToUninstall)
 	},
 }
@@ -59,6 +62,8 @@ func init() {
 	rootCmd.AddCommand(uninstallCmd)
 	uninstallCmd.Flags().BoolVarP(&uninstallAll, "all", "a", false, `Uninstalls all components (Worker, Controller, UI)`)
 	uninstallCmd.Flags().BoolVarP(&uninstallUI, "ui", "u", false, `Uninstalls enterprise UI components (Kubeslice-Manager)`)
+	// TODO: update the controller version after release
+	uninstallCmd.Flags().BoolVarP(&uninstallCertManager, "cert-manager", "", false, `Uninstalls Cert Manager (required for controller version < 0.7.0)`)
 	// TODO: A discussion is needed for graceful cleanup of worker clusters
 	// uninstallCmd.Flags().StringSliceVarP(&uninstallWorker, "worker", "", []string{}, `Uninstalls worker clusters`)
 	// uninstallCmd.Flags().Lookup("worker").NoOptDefVal = "*"

--- a/doc/kubeslice-cli_install.md
+++ b/doc/kubeslice-cli_install.md
@@ -1,4 +1,4 @@
-## kubeslice-cli install
+## ## kubeslice-cli install
 
 Installs workloads to run KubeSlice
 
@@ -15,28 +15,29 @@ kubeslice-cli install [flags]
 ### Options
 
 ```
-  -h, --help             help for install
-  -p, --profile string   <profile-value>
-                         The profile for installation/uninstallation.
-                         Supported values:
-                         	- full-demo:
-                         		Showcases the KubeSlice inter-cluster connectivity by spawning
-                         		3 Kind Clusters, including 1 KubeSlice Controller and 2 KubeSlice Workers, 
-                         		and installing iPerf application to generate network traffic.
-                         	- minimal-demo:
-                         		Sets up 3 Kind Clusters, including 1 KubeSlice Controller and 2 KubeSlice Workers. 
-                         		Generates the KubernetesManifests for user to manually apply, and verify 
-                         		the functionality
-						 Cannot be used with --config flag.
-  -s, --skip strings     Skips the installation steps (comma-seperated). 
-                         Supported values:
-                         	- kind: Skips the creation of kind clusters
-                         	- calico: Skips the installation of Calico
-                         	- controller: Skips the installation of KubeSlice Controller
-                         	- worker-registration: Skips the registration of KubeSlice Workers on the Controller
-                         	- worker: Skips the installation of KubeSlice Worker
-                         	- demo: Skips the installation of additional example applications
-				- ui: Skips the installtion of enterprise UI components (Kubeslice-Manager)
+  -h, --help                help for install
+  -p, --profile string      <profile-value>
+                            The profile for installation/uninstallation.
+                            Supported values:
+                            	- full-demo:
+                            		Showcases the KubeSlice inter-cluster connectivity by spawning
+                            		3 Kind Clusters, including 1 KubeSlice Controller and 2 KubeSlice Workers, 
+                            		and installing iPerf application to generate network traffic.
+                            	- minimal-demo:
+                            		Sets up 3 Kind Clusters, including 1 KubeSlice Controller and 2 KubeSlice Workers. 
+                            		Generates the KubernetesManifests for user to manually apply, and verify 
+                            		the functionality
+                            Cannot be used with --config flag.
+  -s, --skip strings        Skips the installation steps (comma-seperated). 
+                            Supported values:
+                            	- kind: Skips the creation of kind clusters
+                            	- calico: Skips the installation of Calico
+                            	- controller: Skips the installation of KubeSlice Controller
+                            	- worker-registration: Skips the registration of KubeSlice Workers on the Controller
+                            	- worker: Skips the installation of KubeSlice Worker
+                            	- demo: Skips the installation of additional example applications
+                            	- ui: Skips the installtion of enterprise UI components (Kubeslice-Manager)
+      --with-cert-manager   Installs Cert-Manager for kubeslice controller (for versions < 0.7.0)
 ```
 
 ### Options inherited from parent commands

--- a/doc/kubeslice-cli_uninstall.md
+++ b/doc/kubeslice-cli_uninstall.md
@@ -9,9 +9,10 @@ kubeslice-cli uninstall [flags]
 ### Options
 
 ```
-  -a, --all    Uninstalls all components (Worker, Controller, UI)
-  -h, --help   help for uninstall
-  -u, --ui     Uninstalls enterprise UI components (Kubeslice-Manager)
+  -a, --all            Uninstalls all components (Worker, Controller, UI)
+      --cert-manager   Uninstalls Cert Manager (required for controller version < 0.7.0)
+  -h, --help           help for uninstall
+  -u, --ui             Uninstalls enterprise UI components (Kubeslice-Manager)
 ```
 
 ### Options inherited from parent commands

--- a/pkg/internal/bootstrap-configuration.go
+++ b/pkg/internal/bootstrap-configuration.go
@@ -30,7 +30,8 @@ type HelmChart struct {
 }
 
 type KubeSliceConfiguration struct {
-	ProjectName string `yaml:"project_name"`
+	ProjectName  string   `yaml:"project_name"`
+	ProjectUsers []string `yaml:"project_users"`
 }
 
 type ClusterConfiguration struct {

--- a/pkg/internal/constants.go
+++ b/pkg/internal/constants.go
@@ -14,6 +14,7 @@ const (
 	UI_install_Component          = "ui"
 	Worker_Component              = "worker"
 	Demo_Component                = "demo"
+	CertManager_Component         = "cert-manager"
 	SecretObject                  = "secrets"
 	OutputFormatYaml              = "yaml"
 	OutputFormatJson              = "json"

--- a/pkg/internal/helm-repo-add.go
+++ b/pkg/internal/helm-repo-add.go
@@ -57,10 +57,14 @@ func updateHelmChart() {
 func generateImagePullSecretsValue(ImagePullSecret ImagePullSecrets) string {
 	imagePullSecretsValue := ""
 	ips := ImagePullSecret
-	if ips.Registry != "" && ips.Username != "" && ips.Password != "" {
+	if ips.Username != "" && ips.Password != "" {
 		email := ""
 		if ips.Email != "" {
 			email = "email: " + ips.Email
+		}
+		// setting default registry
+		if ips.Registry == "" {
+			ips.Registry = "https://index.docker.io/v1/"
 		}
 		imagePullSecretsValue = fmt.Sprintf(imagePullSecretsTemplate, ips.Registry, ips.Username, ips.Password, email)
 	}

--- a/pkg/internal/project-manifest.go
+++ b/pkg/internal/project-manifest.go
@@ -19,14 +19,13 @@ metadata:
   namespace: kubeslice-controller
 spec:
   serviceAccount:
-    readWrite:
-      - john
+    readWrite: %s
 `
 
 func CreateKubeSliceProject(ApplicationConfiguration *ConfigurationSpecs, cliOptions *CliOptionsStruct) {
 	util.Printf("\nCreating KubeSlice Project...")
 
-	generateKubeSliceProjectManifest(ApplicationConfiguration.Configuration.KubeSliceConfiguration.ProjectName)
+	generateKubeSliceProjectManifest(ApplicationConfiguration.Configuration.KubeSliceConfiguration.ProjectName, ApplicationConfiguration.Configuration.KubeSliceConfiguration.ProjectUsers)
 	util.Printf("%s Generated project manifest %s", util.Tick, projectFileName)
 	time.Sleep(200 * time.Millisecond)
 	if cliOptions != nil {
@@ -47,8 +46,15 @@ func GetKubeSliceProject(projectName string, namespace string, controllerCluster
 	GetKubectlResources(ProjectObject, projectName, namespace, controllerCluster, "")
 	time.Sleep(200 * time.Millisecond)
 }
-func generateKubeSliceProjectManifest(projectName string) {
-	util.DumpFile(fmt.Sprintf(kubesliceProjectTemplate, projectName), kubesliceDirectory+"/"+projectFileName)
+func generateKubeSliceProjectManifest(projectName string, users []string) {
+	if len(users) == 0 {
+		users = []string{"admin"}
+	}
+	userString := "\n"
+	for _, user := range users {
+		userString = fmt.Sprintf(`%s      - %s%s`, userString, user, "\n")
+	}
+	util.DumpFile(fmt.Sprintf(kubesliceProjectTemplate, projectName, userString), kubesliceDirectory+"/"+projectFileName)
 }
 
 func DeleteKubeSliceProject(projectName string, namespace string, controllerCluster *Cluster) {

--- a/pkg/slicectl.go
+++ b/pkg/slicectl.go
@@ -51,6 +51,7 @@ func basicInstall(skipSteps map[string]string) {
 	_, skipWorker := skipSteps[internal.Worker_Component]
 	_, skipWorker_registration := skipSteps[internal.Worker_registration_Component]
 	_, skipUI := skipSteps[internal.UI_install_Component]
+	_, skipCertManager := skipSteps[internal.CertManager_Component]
 
 	internal.GenerateKubeSliceDirectory()
 	if ApplicationConfiguration.Configuration.ClusterConfiguration.Profile != "" {
@@ -69,7 +70,9 @@ func basicInstall(skipSteps map[string]string) {
 	internal.GatherNetworkInformation(ApplicationConfiguration)
 	internal.AddHelmCharts(ApplicationConfiguration)
 	if !skipController {
-		internal.InstallCertManager(ApplicationConfiguration)
+		if !skipCertManager {
+			internal.InstallCertManager(ApplicationConfiguration)
+		}
 		internal.InstallKubeSliceController(ApplicationConfiguration)
 		internal.CreateKubeSliceProject(ApplicationConfiguration, nil)
 	}
@@ -91,6 +94,7 @@ func Uninstall(componentsToUninstall, workersToUninstall map[string]string) {
 	// Custom topology passed
 	if ApplicationConfiguration.Configuration.ClusterConfiguration.Profile == "" {
 		_, uninstallController := componentsToUninstall[internal.Controller_Component]
+		_, uninstallCertManager := componentsToUninstall[internal.CertManager_Component]
 		_, uninstallWorker := componentsToUninstall[internal.Worker_Component]
 		_, uninstallUI := componentsToUninstall[internal.UI_install_Component]
 
@@ -102,7 +106,9 @@ func Uninstall(componentsToUninstall, workersToUninstall map[string]string) {
 		}
 		if uninstallController {
 			internal.UninstallKubeSliceController(ApplicationConfiguration)
-			internal.UninstallCertManager(ApplicationConfiguration)
+			if uninstallCertManager {
+				internal.UninstallCertManager(ApplicationConfiguration)
+			}
 		}
 		return
 	}

--- a/pkg/ui.go
+++ b/pkg/ui.go
@@ -1,0 +1,7 @@
+package pkg
+
+import "github.com/kubeslice/kubeslice-cli/pkg/internal"
+
+func GetUIEndpoint() {
+	internal.GetUIEndpoint(CliOptions.Cluster)
+}

--- a/samples/template.yaml
+++ b/samples/template.yaml
@@ -53,7 +53,7 @@ configuration:
     helm_username: #{Helm Username if the repo is private}
     helm_password: #{Helm Password if the repo is private}
     image_pull_secret: #{The image pull secrets. Optional for OpenSource, required for enterprise}
-      registry: #{The endpoint of the OCI registry to use}
+      registry: #{The endpoint of the OCI registry to use. Default is `https://index.docker.io/v1/`} 
       username: #{The username to authenticate against the OCI registry}
       password: #{The password to authenticate against the OCI registry}
       email: #{The email to authenticate against the OCI registry}

--- a/samples/template.yaml
+++ b/samples/template.yaml
@@ -31,6 +31,7 @@ configuration:
                #{Override this flag to an address which is discoverable by other clusters in the topology}
   kubeslice_configuration:
     project_name: #{the name of the KubeSlice Project}
+    project_users: #{optional: specify KubeSlice Project users with Readw-Write access. Default is admin}
   helm_chart_configuration:
     repo_alias: #{The alias of the helm repo for KubeSlice Charts}
     repo_url: #{The URL of the Helm Charts for KubeSlice}


### PR DESCRIPTION

# Description
What's new:
- If a user does not pass the registry endpoint it defaults to `https://index.docker.io/v1/`
- Added flags to support cert-manager installation for previous controller versions. The default behaviour is NOT to install or uninstall cert-manager (unless specified)
- - `--with-cert-manager` for install cmd
- - `--cert-manager` for uninstall cmd
- Added option to fetch Kubeslice manager Endpoint
- - `kubectl get ui-endpoint`
- Providing a configurable field in config topology to add users to the project

Closes #34 #39  #42  #44 

## How Has This Been Tested?
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

test-cases
- [ ] Test case A
- [ ] Test case B
-->

## Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] Does this PR requires documentation updates?
* [x] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code.
* [x] I have commented my code, particularly in hard-to-understand areas.
* [x] I have tested it for all user roles.
* [ ] I have added all the required unit test cases.

## Does this PR introduce a breaking change?
<!--
If NO, leave the release-note block blank.
If YES, a release note is required:
Enter your extended release note in the block below. If the PR requires additional manual action from users switching to the new version, include the string "action-required".
-->

```release-note

```

