### PR TITLE
feat(): Add support for enterprise demo

### DIFF
--- a/cmd/install.go
+++ b/cmd/install.go
@@ -30,7 +30,9 @@ var installCmd = &cobra.Command{
 		if profile != "" {
 			switch profile {
 			case pkg.ProfileFullDemo:
+				skipSteps = append(skipSteps, "prometheus")
 			case pkg.ProfileMinimalDemo:
+				skipSteps = append(skipSteps, "prometheus")
 			case pkg.ProfileEntDemo:
 			default:
 				util.Fatalf("%v Unknown profile: %s. Possible values %s", util.Cross, profile, []string{pkg.ProfileFullDemo, pkg.ProfileMinimalDemo, pkg.ProfileEntDemo})
@@ -43,6 +45,7 @@ var installCmd = &cobra.Command{
 		if !withCertManager {
 			skipSteps = append(skipSteps, "cert-manager")
 		}
+
 		stepsToSkipMap := mapFromSlice(skipSteps)
 		pkg.Install(stepsToSkipMap)
 	},
@@ -80,7 +83,8 @@ Supported values:
 	- worker-registration: Skips the registration of KubeSlice Workers on the Controller
 	- worker: Skips the installation of KubeSlice Worker
 	- demo: Skips the installation of additional example applications
-	- ui: Skips the installtion of enterprise UI components (Kubeslice-Manager)`)
+	- ui: Skips the installtion of enterprise UI components (Kubeslice-Manager)
+	- prometheus: Skips the installation of prometheus`)
 	installCmd.Flags().BoolVarP(&withCertManager, "with-cert-manager", "", false, `Installs Cert-Manager for kubeslice controller (for versions < 0.7.0)`)
 
 }

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -31,13 +31,13 @@ var installCmd = &cobra.Command{
 			switch profile {
 			case pkg.ProfileFullDemo:
 			case pkg.ProfileMinimalDemo:
+			case pkg.ProfileEntDemo:
 			default:
-				util.Fatalf("%v Unknown profile: %s. Possible values %s", util.Cross, profile, []string{pkg.ProfileFullDemo, pkg.ProfileMinimalDemo})
+				util.Fatalf("%v Unknown profile: %s. Possible values %s", util.Cross, profile, []string{pkg.ProfileFullDemo, pkg.ProfileMinimalDemo, pkg.ProfileEntDemo})
 			}
-			pkg.ReadAndValidateConfiguration("")
-			pkg.ApplicationConfiguration.Configuration.ClusterConfiguration.Profile = profile
+			pkg.ReadAndValidateConfiguration("", profile)
 		} else {
-			pkg.ReadAndValidateConfiguration(Config)
+			pkg.ReadAndValidateConfiguration(Config, "")
 		}
 		// Default behaviour is not ot install cert-manager
 		if !withCertManager {
@@ -61,6 +61,16 @@ Supported values:
 		Sets up 3 Kind Clusters, including 1 KubeSlice Controller and 2 KubeSlice Workers. 
 		Generates the KubernetesManifests for user to manually apply, and verify 
 		the functionality
+	- enterprise-demo:
+		Showcases the KubeSlice Enterprise functionality by spawning
+		3 Kind Clusters, including 1 KubeSlice Controller and 2 KubeSlice Workers, 
+		installing the enterprise charts for Controller and Worker with KubeSlice Manager (UI),
+		and installing iPerf application to generate network traffic. 
+		Ensure that the imagePullSecrets (username and password) are set as environment variables.
+
+		KUBESLICE_IMAGE_PULL_USERNAME : optional : Default 'aveshaenterprise'
+		KUBESLICE_IMAGE_PULL_PASSWORD : required
+
 Cannot be used with --config flag.`)
 	installCmd.Flags().StringSliceVarP(&skipSteps, "skip", "s", []string{}, `Skips the installation steps (comma-seperated). 
 Supported values:
@@ -71,7 +81,6 @@ Supported values:
 	- worker: Skips the installation of KubeSlice Worker
 	- demo: Skips the installation of additional example applications
 	- ui: Skips the installtion of enterprise UI components (Kubeslice-Manager)`)
-	// TODO: update the controller version after release
 	installCmd.Flags().BoolVarP(&withCertManager, "with-cert-manager", "", false, `Installs Cert-Manager for kubeslice controller (for versions < 0.7.0)`)
 
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -22,6 +22,7 @@ KubeSlice functionality`,
 		cmd.Help()
 	},
 }
+var RootCmd = rootCmd
 
 func Execute() {
 	rootCmd.PersistentFlags().StringVarP(&Config, "config", "c", "", `<path-to-topology-configuration-yaml-file>

--- a/cmd/uninstall.go
+++ b/cmd/uninstall.go
@@ -21,7 +21,7 @@ var uninstallCmd = &cobra.Command{
 	Short:   "Performs cleanup of Kubeslice components.",
 	Args:    cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
-		pkg.ReadAndValidateConfiguration(Config)
+		pkg.ReadAndValidateConfiguration(Config, "")
 		// if --all flag is passed, other flags should not be allowed
 		if uninstallAll && uninstallUI {
 			cmd.Help()

--- a/doc/kubeslice-cli_install.md
+++ b/doc/kubeslice-cli_install.md
@@ -1,4 +1,4 @@
-## ## kubeslice-cli install
+## kubeslice-cli install
 
 Installs workloads to run KubeSlice
 
@@ -27,6 +27,16 @@ kubeslice-cli install [flags]
                             		Sets up 3 Kind Clusters, including 1 KubeSlice Controller and 2 KubeSlice Workers. 
                             		Generates the KubernetesManifests for user to manually apply, and verify 
                             		the functionality
+                            	- enterprise-demo:
+                            		Showcases the KubeSlice Enterprise functionality by spawning
+                            		3 Kind Clusters, including 1 KubeSlice Controller and 2 KubeSlice Workers, 
+                            		installing the enterprise charts for Controller and Worker with KubeSlice Manager (UI),
+                            		and installing iPerf application to generate network traffic. 
+                            		Ensure that the imagePullSecrets (username and password) are set as environment variables.
+                            
+                            		KUBESLICE_IMAGE_PULL_USERNAME : optional : Default 'aveshaenterprise'
+                            		KUBESLICE_IMAGE_PULL_PASSWORD : required
+                            
                             Cannot be used with --config flag.
   -s, --skip strings        Skips the installation steps (comma-seperated). 
                             Supported values:
@@ -37,6 +47,7 @@ kubeslice-cli install [flags]
                             	- worker: Skips the installation of KubeSlice Worker
                             	- demo: Skips the installation of additional example applications
                             	- ui: Skips the installtion of enterprise UI components (Kubeslice-Manager)
+                            	- prometheus: Skips the installation of prometheus
       --with-cert-manager   Installs Cert-Manager for kubeslice controller (for versions < 0.7.0)
 ```
 
@@ -51,5 +62,3 @@ kubeslice-cli install [flags]
 ### SEE ALSO
 
 * [kubeslice-cli](kubeslice-cli.md)	 - kubeslice-cli - a simple CLI for KubeSlice Operations
-
-

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.17
 require (
 	github.com/go-yaml/yaml v2.1.0+incompatible
 	github.com/spf13/cobra v1.6.1
+	gopkg.in/yaml.v2 v2.4.0
 	sigs.k8s.io/yaml v1.2.0
 )
 
@@ -14,7 +15,6 @@ require (
 	github.com/tidwall/gjson v1.14.2 // indirect
 	github.com/tidwall/match v1.1.1 // indirect
 	github.com/tidwall/pretty v1.2.0 // indirect
-	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 

--- a/pkg/cmd-util.go
+++ b/pkg/cmd-util.go
@@ -104,6 +104,9 @@ var defaultEntConfiguration = &internal.HelmChartConfiguration{
 			"kubeslice.uiproxy.service.nodePort": 31000,
 		},
 	},
+	PrometheusChart: internal.HelmChart{
+		ChartName: "prometheus",
+	},
 }
 
 func readConfiguration(fileName string) *internal.ConfigurationSpecs {

--- a/pkg/cmd-util.go
+++ b/pkg/cmd-util.go
@@ -100,6 +100,9 @@ var defaultEntConfiguration = &internal.HelmChartConfiguration{
 	},
 	UIChart: internal.HelmChart{
 		ChartName: "kubeslice-ui",
+		Values: map[string]interface{}{
+			"kubeslice.uiproxy.service.nodePort": 31000,
+		},
 	},
 }
 

--- a/pkg/cmd-util.go
+++ b/pkg/cmd-util.go
@@ -3,6 +3,7 @@ package pkg
 import (
 	"fmt"
 	"io/ioutil"
+	"os"
 
 	"github.com/go-yaml/yaml"
 	"github.com/kubeslice/kubeslice-cli/pkg/internal"
@@ -12,6 +13,8 @@ import (
 const (
 	ProfileFullDemo    = "full-demo"
 	ProfileMinimalDemo = "minimal-demo"
+	ProfileEntDemo     = "enterprise-demo"
+	ClusterTypeKind    = "kind"
 )
 
 type CliParams struct {
@@ -30,7 +33,7 @@ var CliOptions *internal.CliOptionsStruct
 
 func SetCliOptions(cliParams CliParams) {
 	var controllerCluster *internal.Cluster
-	configSpecs := ReadAndValidateConfiguration(cliParams.Config)
+	configSpecs := ReadAndValidateConfiguration(cliParams.Config, "")
 	if cliParams.Config != "" {
 		controllerCluster = &configSpecs.Configuration.ClusterConfiguration.ControllerCluster
 	}
@@ -83,6 +86,23 @@ var defaultConfiguration = &internal.ConfigurationSpecs{
 	},
 }
 
+var defaultEntConfiguration = &internal.HelmChartConfiguration{
+	RepoAlias: "kubeslice-ent-demo",
+	RepoUrl:   "https://kubeslice.aveshalabs.io/repository/kubeslice-helm-ent-prod/",
+	CertManagerChart: internal.HelmChart{
+		ChartName: "cert-manager",
+	},
+	ControllerChart: internal.HelmChart{
+		ChartName: "kubeslice-controller",
+	},
+	WorkerChart: internal.HelmChart{
+		ChartName: "kubeslice-worker",
+	},
+	UIChart: internal.HelmChart{
+		ChartName: "kubeslice-ui",
+	},
+}
+
 func readConfiguration(fileName string) *internal.ConfigurationSpecs {
 	file, err := ioutil.ReadFile(fileName)
 	if err != nil {
@@ -105,13 +125,28 @@ func validateConfiguration(specs *internal.ConfigurationSpecs) []string {
 	cc := &specs.Configuration.ClusterConfiguration
 	ksc := &specs.Configuration.KubeSliceConfiguration
 	hc := &specs.Configuration.HelmChartConfiguration
+	if hc.ImagePullSecret.Password == "" {
+		hc.ImagePullSecret.Password = os.Getenv("KUBESLICE_IMAGE_PULL_PASSWORD")
+	}
+	if hc.ImagePullSecret.Username == "" {
+		if os.Getenv("KUBESLICE_IMAGE_PULL_USERNAME") == "" {
+			hc.ImagePullSecret.Username = "aveshaenterprise"
+		} else {
+			hc.ImagePullSecret.Username = os.Getenv("KUBESLICE_IMAGE_PULL_USERNAME")
+		}
+
+	}
 	if cc.Profile != "" {
 		switch cc.Profile {
 		case ProfileFullDemo:
 		case ProfileMinimalDemo:
+		case ProfileEntDemo:
+			if hc.ImagePullSecret.Password == "" {
+				errors = append(errors, fmt.Sprintf("%s Missing image pull secret password. Please set environment variable `KUBESLICE_IMAGE_PULL_PASSWORD`", util.Cross))
+			}
 		default:
 			errors = append(errors, fmt.Sprintf("%s Unknown profile: %s. Possible values %s", util.Cross, cc.Profile, []string{ProfileFullDemo,
-				ProfileMinimalDemo}))
+				ProfileMinimalDemo, ProfileEntDemo}))
 		}
 		if cc.KubeConfigPath != "" || cc.ControllerCluster.KubeConfigPath != "" {
 			errors = append(errors, fmt.Sprintf("%s Cannot specify configuration.cluster_configuration.kube_config_path or configuration.cluster_configuration.controller.kube_config_path when running a kind cluster demo", util.Cross))
@@ -185,12 +220,19 @@ func validateConfiguration(specs *internal.ConfigurationSpecs) []string {
 	return errors
 }
 
-func ReadAndValidateConfiguration(fileName string) *internal.ConfigurationSpecs {
+func ReadAndValidateConfiguration(fileName, profile string) *internal.ConfigurationSpecs {
 	var specs *internal.ConfigurationSpecs
 	if fileName != "" {
 		specs = readConfiguration(fileName)
 	} else {
 		specs = defaultConfiguration
+		specs.Configuration.ClusterConfiguration.ClusterType = ClusterTypeKind
+		// Set defaults for ent demo
+		if profile == ProfileEntDemo {
+			specs.Configuration.ClusterConfiguration.Profile = ProfileEntDemo
+			specs.Configuration.HelmChartConfiguration = *defaultEntConfiguration
+		}
+
 	}
 	errors := validateConfiguration(specs)
 	if len(errors) > 0 {

--- a/pkg/internal/bootstrap-configuration.go
+++ b/pkg/internal/bootstrap-configuration.go
@@ -26,7 +26,7 @@ type HelmChart struct {
 	ChartName string `yaml:"chart_name"`
 	Version   string `yaml:"version"`
 	// Values to be passed as --set arguments to helm install
-	Values map[string]string `yaml:"values"`
+	Values map[string]interface{} `yaml:"values"`
 }
 
 type KubeSliceConfiguration struct {

--- a/pkg/internal/bootstrap-configuration.go
+++ b/pkg/internal/bootstrap-configuration.go
@@ -17,6 +17,7 @@ type HelmChartConfiguration struct {
 	ControllerChart  HelmChart        `yaml:"controller_chart"`
 	WorkerChart      HelmChart        `yaml:"worker_chart"`
 	UIChart          HelmChart        `yaml:"ui_chart"`
+	PrometheusChart  HelmChart        `yaml:"prometheus_chart"`
 	HelmUsername     string           `yaml:"helm_username"`
 	HelmPassword     string           `yaml:"helm_password"`
 	ImagePullSecret  ImagePullSecrets `yaml:"image_pull_secret"`

--- a/pkg/internal/cluster-manifests.go
+++ b/pkg/internal/cluster-manifests.go
@@ -18,9 +18,29 @@ metadata:
   name: %s 
   namespace: %s
 spec:
+  clusterProperty: %s
 ---
 
 `
+const regionTemplate1 = `
+    geoLocation:
+      cloudProvider: GCP
+      cloudRegion: custom
+      latitude: "36.7783"
+      longitude: "-119.4179"
+`
+const regionTemplate2 = `
+    geoLocation:
+      cloudProvider: DATACENTER
+      cloudRegion: custom
+      latitude: "40.6976633"
+      longitude: "-74.1201054"
+`
+
+var regionTemplates = map[string]string{
+	"ks-w-1": regionTemplate1,
+	"ks-w-2": regionTemplate2,
+}
 
 func RegisterWorkerClusters(ApplicationConfiguration *ConfigurationSpecs, cliOptions *CliOptionsStruct) {
 	util.Printf("\nRegistering Worker Clusters with Project...")
@@ -50,11 +70,15 @@ func RegisterWorkerClusters(ApplicationConfiguration *ConfigurationSpecs, cliOpt
 
 func generateClusterRegistrationManifest(ApplicationConfiguration *ConfigurationSpecs, filename string, namespace string) {
 	var clusterRegistrationContent = ""
+	var regionTemplate = "{}"
 	if namespace == "" {
 		namespace = "kubeslice-" + ApplicationConfiguration.Configuration.KubeSliceConfiguration.ProjectName
 	}
 	for _, cluster := range ApplicationConfiguration.Configuration.ClusterConfiguration.WorkerClusters {
-		clusterRegistrationContent = clusterRegistrationContent + fmt.Sprintf(clusterRegistrationTemplate, cluster.Name, namespace)
+		if ApplicationConfiguration.Configuration.ClusterConfiguration.Profile == ProfileEntDemo {
+			regionTemplate = regionTemplates[cluster.Name]
+		}
+		clusterRegistrationContent = clusterRegistrationContent + fmt.Sprintf(clusterRegistrationTemplate, cluster.Name, namespace, regionTemplate)
 	}
 	util.DumpFile(clusterRegistrationContent, filename)
 }

--- a/pkg/internal/cluster-manifests.go
+++ b/pkg/internal/cluster-manifests.go
@@ -18,7 +18,6 @@ metadata:
   name: %s 
   namespace: %s
 spec:
-  networkInterface: eth0
 ---
 
 `

--- a/pkg/internal/constants.go
+++ b/pkg/internal/constants.go
@@ -15,6 +15,7 @@ const (
 	Worker_Component              = "worker"
 	Demo_Component                = "demo"
 	CertManager_Component         = "cert-manager"
+	Prometheus_Component          = "prometheus"
 	SecretObject                  = "secrets"
 	OutputFormatYaml              = "yaml"
 	OutputFormatJson              = "json"

--- a/pkg/internal/enterprise.go
+++ b/pkg/internal/enterprise.go
@@ -33,11 +33,17 @@ func InstallKubeSliceUI(ApplicationConfiguration *ConfigurationSpecs) {
 	cc := ApplicationConfiguration.Configuration.ClusterConfiguration
 	hc := ApplicationConfiguration.Configuration.HelmChartConfiguration
 	time.Sleep(200 * time.Millisecond)
+
 	clusterType := ApplicationConfiguration.Configuration.ClusterConfiguration.ClusterType
+	filename := "helm-values-ui.yaml"
 	generateUIValuesFile(clusterType, cc.ControllerCluster, ApplicationConfiguration.Configuration.HelmChartConfiguration)
+	util.Printf("%s Generated Helm Values file for Kubeslice Manager Installation %s", util.Tick, filename)
+	time.Sleep(200 * time.Millisecond)
+
 	installKubeSliceUI(cc.ControllerCluster, hc)
 	util.Printf("%s Successfully installed helm chart %s/%s", util.Tick, hc.RepoAlias, hc.UIChart.ChartName)
 	time.Sleep(200 * time.Millisecond)
+
 	util.Printf("%s Waiting for KubeSlice Manager Pods to be Healthy...", util.Wait)
 	PodVerification("Waiting for KubeSlice Manager Pods to be Healthy", cc.ControllerCluster, "kubernetes-dashboard")
 	util.Printf("%s Successfully installed KubeSlice Manager.\n", util.Tick)

--- a/pkg/internal/enterprise.go
+++ b/pkg/internal/enterprise.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -100,7 +101,7 @@ func uninstallKubeSliceUI(cluster Cluster) (bool, error) {
 	return true, nil
 }
 
-func GetUIEndpoint(cc *Cluster) {
+func GetUIEndpoint(cc *Cluster, profile string) string {
 	util.Printf("\nFetching KubeSlice Manager Endpoint...")
 	ep := ""
 
@@ -114,18 +115,22 @@ func GetUIEndpoint(cc *Cluster) {
 		}
 		switch jsonMap["type"] {
 		case "NodePort":
-			ports := jsonMap["ports"].([]interface{})
-			for _, port := range ports {
-				portMap := port.(map[string]interface{})
-				if portMap["name"] == "http" { // Assuming that http is the name of the port that you want to use
-					nodePort := int(portMap["nodePort"].(float64))
-					nodeIP, err := getNodeIP(cc)
-					if err == nil {
-						ep = fmt.Sprintf("https://%s:%d", strings.Trim(nodeIP, "'"), nodePort)
-					} else {
-						util.Printf("%s Unable to get node IP. Err: %v", util.Cross, err)
+			if profile == ProfileEntDemo {
+				ep = fmt.Sprintf("https://%s:%d", "localhost", 8443)
+			} else {
+				ports := jsonMap["ports"].([]interface{})
+				for _, port := range ports {
+					portMap := port.(map[string]interface{})
+					if portMap["name"] == "http" { // Assuming that http is the name of the port that you want to use
+						nodePort := int(portMap["nodePort"].(float64))
+						nodeIP, err := getNodeIP(cc)
+						if err == nil {
+							ep = fmt.Sprintf("https://%s:%d", strings.Trim(nodeIP, "'"), nodePort)
+						} else {
+							util.Printf("%s Unable to get node IP. Err: %v", util.Cross, err)
+						}
+						break
 					}
-					break
 				}
 			}
 		case "LoadBalancer":
@@ -151,6 +156,46 @@ func GetUIEndpoint(cc *Cluster) {
 	} else {
 		util.Printf("%s Visit %v from your browser to access the Kubeslice Manager.", util.Tick, ep)
 	}
+	return ep
+}
+
+func findUserSecret(username string, projectName string, cc Cluster) string {
+	var outB, errB bytes.Buffer
+	err := util.RunCommandCustomIO("kubectl", &outB, &errB, true, "--context="+cc.ContextName, "--kubeconfig="+cc.KubeConfigPath, "get", "sa", "-n", "kubeslice-"+projectName, "-o", "name")
+	if err != nil {
+		log.Fatalf("Process failed %v", err)
+	}
+
+	var secret string
+	for _, line := range strings.Split(outB.String(), "\n") {
+		if strings.Contains(line, "rbac-rw-"+username) {
+			secret = fmt.Sprintf("secrets/%s", strings.TrimPrefix(line, "serviceaccount/"))
+			break
+		}
+	}
+	if secret == "" {
+		log.Fatalf("failed to find secret for %s", username)
+	}
+	return secret
+}
+
+func GetUIAdminToken(cc *Cluster, username, projectName string) string {
+	util.Printf("\nFetching KubeSlice Manager Admin Token...")
+	secret := findUserSecret(username, projectName, *cc)
+
+	var outB, errB bytes.Buffer
+	err := util.RunCommandCustomIO("kubectl", &outB, &errB, false, "--context="+cc.ContextName, "--kubeconfig="+cc.KubeConfigPath, "get", secret, "-n", "kubeslice-"+projectName, "-o", "jsonpath={.data.token}")
+	if err != nil {
+		log.Fatalf("Process failed %v", err)
+	}
+	x := outB.String()
+	// base64 decode
+	data, err := base64.StdEncoding.DecodeString(x)
+	if err != nil {
+		log.Fatalf("Unable to decode token %v", err)
+	}
+	return string(data)
+
 }
 
 func getNodeIP(cc *Cluster) (string, error) {

--- a/pkg/internal/project-manifest.go
+++ b/pkg/internal/project-manifest.go
@@ -37,7 +37,7 @@ func CreateKubeSliceProject(ApplicationConfiguration *ConfigurationSpecs, cliOpt
 		ApplyKubectlManifest(kubesliceDirectory+"/"+projectFileName, KUBESLICE_CONTROLLER_NAMESPACE, &ApplicationConfiguration.Configuration.ClusterConfiguration.ControllerCluster)
 	}
 	util.Printf("%s Applied %s", util.Tick, projectFileName)
-	time.Sleep(200 * time.Millisecond)
+	time.Sleep(3 * time.Second)
 	util.Printf("Created KubeSlice Project.")
 }
 

--- a/pkg/internal/prometheus.go
+++ b/pkg/internal/prometheus.go
@@ -1,0 +1,69 @@
+package internal
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/kubeslice/kubeslice-cli/util"
+)
+
+const (
+	PrometheusValuesFileName = "helm-values-Prometheus.yaml"
+	PrometheusNamespace      = "monitoring"
+)
+
+func InstallPrometheus(ApplicationConfiguration *ConfigurationSpecs) {
+	util.Printf("\nInstalling Prometheus...")
+
+	wc := ApplicationConfiguration.Configuration.ClusterConfiguration.WorkerClusters
+	cc := ApplicationConfiguration.Configuration.ClusterConfiguration.ControllerCluster
+	hc := ApplicationConfiguration.Configuration.HelmChartConfiguration
+	generatePrometheusValuesFile(hc)
+	util.Printf("%s Generated Helm Values file for Prometheus Installation %s", util.Tick, PrometheusValuesFileName)
+	time.Sleep(200 * time.Millisecond)
+	installPrometheus(wc, &cc, hc, PrometheusValuesFileName)
+	util.Printf("%s Successfully installed Prometheus on Worker clusters.", util.Tick)
+	time.Sleep(200 * time.Millisecond)
+	util.Printf("%s Setting Prometheus endpoint in cluster objects...", util.Wait)
+	projectNamespce := fmt.Sprintf("kubeslice-%s", ApplicationConfiguration.Configuration.KubeSliceConfiguration.ProjectName)
+	patchClusterObjectInControllerCluster(wc, &cc, projectNamespce)
+}
+
+func patchClusterObjectInControllerCluster(wc []Cluster, cc *Cluster, projectNS string) {
+	for _, cluster := range wc {
+		// Patch cluster object in controller cluster
+		err := util.RunCommand("kubectl", "--context", cc.ContextName, "--kubeconfig", cc.KubeConfigPath, "patch", ClusterObject, cluster.Name, "-n", projectNS, "--type", "merge", "-p", fmt.Sprintf("{\"spec\":{\"clusterProperty\":{\"telemetry\":{\"enabled\":true,\"endpoint\":\"http://%s:32700\",\"telemetryProvider\":\"prometheus\"}}}}", cluster.NodeIP))
+		if err != nil {
+			log.Fatalf("Process failed %v", err)
+		}
+		util.Printf("%s Successfully set prometheus endpoint in %s", util.Tick, cluster.Name)
+	}
+}
+
+func generatePrometheusValuesFile(hcConfig HelmChartConfiguration) {
+	err := generateValuesFile(kubesliceDirectory+"/"+PrometheusValuesFileName, &hcConfig.PrometheusChart, "")
+	if err != nil {
+		log.Fatalf("%s %s", util.Cross, err)
+	}
+}
+
+func installPrometheus(clusters []Cluster, cc *Cluster, hc HelmChartConfiguration, filename string) {
+	for _, cluster := range clusters {
+		args := make([]string, 0)
+		args = append(args, "--kube-context", cluster.ContextName, "--kubeconfig", cluster.KubeConfigPath, "upgrade", "-i", hc.PrometheusChart.ChartName, fmt.Sprintf("%s/%s", hc.RepoAlias, hc.PrometheusChart.ChartName), "--namespace", PrometheusNamespace, "--create-namespace", "-f", kubesliceDirectory+"/"+filename)
+		if hc.ControllerChart.Version != "" {
+			args = append(args, "--version", hc.PrometheusChart.Version)
+		}
+		err := util.RunCommand("helm", args...)
+		if err != nil {
+			log.Fatalf("Process failed %v", err)
+		}
+		util.Printf("%s Successfully installed helm chart %s/%s on cluster %s", util.Tick, hc.RepoAlias, hc.PrometheusChart.ChartName, cluster.Name)
+		time.Sleep(200 * time.Millisecond)
+		util.Printf("%s Waiting for Prometheus Pods to be Healthy...", util.Wait)
+		PodVerification("Waiting for Prometheus Pods to be Healthy", cluster, PrometheusNamespace)
+		// Patch cluster object in controller cluster
+	}
+
+}

--- a/pkg/internal/worker.go
+++ b/pkg/internal/worker.go
@@ -131,7 +131,7 @@ func fetchSecret(clusterName string, cc Cluster, projectName string) map[string]
 	secret := findSecret(clusterName, projectName, cc)
 	//kubectl get secret/kubeslice-rbac-worker-kubeslice-worker-1-token-h99pc -n kubeslice-demo -o jsonpath={.data}
 	var outB, errB bytes.Buffer
-	err := util.RunCommandCustomIO("kubectl", &outB, &errB, false, "--context="+cc.ContextName, "--kubeconfig="+cc.KubeConfigPath, "get", secret, "-n", "kubeslice-"+projectName, "-o", "jsonpath={.data}")
+	err := util.RunCommandCustomIO("kubectl", &outB, &errB, true, "--context="+cc.ContextName, "--kubeconfig="+cc.KubeConfigPath, "get", secret, "-n", "kubeslice-"+projectName, "-o", "jsonpath={.data}")
 	if err != nil {
 		log.Fatalf("Process failed %v", err)
 	}
@@ -145,7 +145,7 @@ func fetchSecret(clusterName string, cc Cluster, projectName string) map[string]
 
 func findSecret(workerName string, projectName string, cc Cluster) string {
 	var outB, errB bytes.Buffer
-	err := util.RunCommandCustomIO("kubectl", &outB, &errB, false, "--context="+cc.ContextName, "--kubeconfig="+cc.KubeConfigPath, "get", "sa", "-n", "kubeslice-"+projectName, "-o", "name")
+	err := util.RunCommandCustomIO("kubectl", &outB, &errB, true, "--context="+cc.ContextName, "--kubeconfig="+cc.KubeConfigPath, "get", "sa", "-n", "kubeslice-"+projectName, "-o", "name")
 	if err != nil {
 		log.Fatalf("Process failed %v", err)
 	}

--- a/pkg/internal/worker.go
+++ b/pkg/internal/worker.go
@@ -22,7 +22,6 @@ metrics:
 
 cluster:
   name: %s
-  nodeIp: %s
   endpoint: %s
 
 `
@@ -97,7 +96,7 @@ func generateWorkerValuesFile(cluster Cluster, valuesFile string, config Configu
 	if err != nil {
 		log.Fatalf("Unable to fetch secrets\n%s", err)
 	}
-	err = generateValuesFile(kubesliceDirectory+"/"+valuesFile, &config.HelmChartConfiguration.WorkerChart, fmt.Sprintf(workerValuesTemplate+generateImagePullSecretsValue(config.HelmChartConfiguration.ImagePullSecret), secrets["namespace"], secrets["controllerEndpoint"], secrets["ca.crt"], secrets["token"], insecureMetrics, cluster.Name, cluster.NodeIP, cluster.ControlPlaneAddress))
+	err = generateValuesFile(kubesliceDirectory+"/"+valuesFile, &config.HelmChartConfiguration.WorkerChart, fmt.Sprintf(workerValuesTemplate+generateImagePullSecretsValue(config.HelmChartConfiguration.ImagePullSecret), secrets["namespace"], secrets["controllerEndpoint"], secrets["ca.crt"], secrets["token"], insecureMetrics, cluster.Name, cluster.ControlPlaneAddress))
 	if err != nil {
 		log.Fatalf("%s %s", util.Cross, err)
 	}

--- a/pkg/internal/worker.go
+++ b/pkg/internal/worker.go
@@ -18,7 +18,7 @@ controllerSecret:
   ca.crt: %s
   token: %s
 metrics:
-  insecure: %s
+  insecure: %t
 
 cluster:
   name: %s
@@ -32,7 +32,7 @@ func InstallKubeSliceWorker(ApplicationConfiguration *ConfigurationSpecs) {
 	cc := ApplicationConfiguration.Configuration.ClusterConfiguration
 	for _, cluster := range cc.WorkerClusters {
 		filename := "helm-values-" + cluster.Name + ".yaml"
-		insecureMetrics := ApplicationConfiguration.Configuration.ClusterConfiguration.ControllerCluster.Name == Kind_Component
+		insecureMetrics := ApplicationConfiguration.Configuration.ClusterConfiguration.ClusterType == Kind_Component
 		generateWorkerValuesFile(cluster,
 			filename,
 			ApplicationConfiguration.Configuration,

--- a/pkg/slicectl.go
+++ b/pkg/slicectl.go
@@ -15,6 +15,8 @@ func Install(skipSteps map[string]string) {
 			fullDemo()
 		case ProfileMinimalDemo:
 			minimalDemo()
+		case ProfileEntDemo:
+			entDemo()
 		}
 	}
 }
@@ -40,6 +42,15 @@ func minimalDemo() {
 	internal.InstallIPerf(ApplicationConfiguration)
 	internal.GenerateIPerfServiceExportManifest(ApplicationConfiguration)
 	internal.PrintNextSteps(false, ApplicationConfiguration)
+}
+
+func entDemo() {
+	//  TODO: Add enterprise demo applications like bookinfo etc.
+	internal.GenerateSliceConfiguration(ApplicationConfiguration, nil, "", "")
+	internal.ApplySliceConfiguration(ApplicationConfiguration)
+	util.Printf("%s Waiting for configuration propagation", util.Wait)
+	time.Sleep(20 * time.Second)
+	internal.PrintNextSteps(true, ApplicationConfiguration)
 }
 
 func basicInstall(skipSteps map[string]string) {

--- a/pkg/slicectl.go
+++ b/pkg/slicectl.go
@@ -87,14 +87,14 @@ func basicInstall(skipSteps map[string]string) {
 		internal.InstallKubeSliceController(ApplicationConfiguration)
 		internal.CreateKubeSliceProject(ApplicationConfiguration, nil)
 	}
+	if !skipUI {
+		internal.InstallKubeSliceUI(ApplicationConfiguration)
+	}
 	if !skipWorker_registration {
 		internal.RegisterWorkerClusters(ApplicationConfiguration, nil)
 	}
 	if !skipWorker {
 		internal.InstallKubeSliceWorker(ApplicationConfiguration)
-	}
-	if !skipUI {
-		internal.InstallKubeSliceUI(ApplicationConfiguration)
 	}
 }
 

--- a/pkg/slicectl.go
+++ b/pkg/slicectl.go
@@ -63,6 +63,11 @@ func basicInstall(skipSteps map[string]string) {
 	_, skipWorker_registration := skipSteps[internal.Worker_registration_Component]
 	_, skipUI := skipSteps[internal.UI_install_Component]
 	_, skipCertManager := skipSteps[internal.CertManager_Component]
+	_, skipPrometheus := skipSteps[internal.Prometheus_Component]
+
+	if ApplicationConfiguration.Configuration.HelmChartConfiguration.PrometheusChart.ChartName == "" {
+		skipPrometheus = true
+	}
 
 	internal.GenerateKubeSliceDirectory()
 	if ApplicationConfiguration.Configuration.ClusterConfiguration.Profile != "" {
@@ -95,6 +100,9 @@ func basicInstall(skipSteps map[string]string) {
 	}
 	if !skipWorker {
 		internal.InstallKubeSliceWorker(ApplicationConfiguration)
+	}
+	if !skipPrometheus {
+		internal.InstallPrometheus(ApplicationConfiguration)
 	}
 }
 

--- a/pkg/ui.go
+++ b/pkg/ui.go
@@ -3,5 +3,5 @@ package pkg
 import "github.com/kubeslice/kubeslice-cli/pkg/internal"
 
 func GetUIEndpoint() {
-	internal.GetUIEndpoint(CliOptions.Cluster)
+	internal.GetUIEndpoint(CliOptions.Cluster, ApplicationConfiguration.Configuration.ClusterConfiguration.Profile)
 }

--- a/samples/template.yaml
+++ b/samples/template.yaml
@@ -50,6 +50,10 @@ configuration:
       chart_name: #{The name of the UI/Enterprise Chart}
       version: #{The version of the chart to use. Leave blank for latest version}
       values: #(Values to be passed as --set arguments to helm install)
+    prometheus_chart:
+      chart_name: #{The name of the Prometheus Chart}
+      version: #{The version of the chart to use. Leave blank for latest version}
+      values: #(Values to be passed as --set arguments to helm install)
     helm_username: #{Helm Username if the repo is private}
     helm_password: #{Helm Password if the repo is private}
     image_pull_secret: #{The image pull secrets. Optional for OpenSource, required for enterprise}

--- a/util/print-util.go
+++ b/util/print-util.go
@@ -11,6 +11,8 @@ const (
 	Wait  = string(rune(0x267B))
 	Run   = string(rune(0x1F3C3))
 	Warn  = string(rune(0x26A0))
+	Lock  = string(rune(0x1F512))
+	Globe = string(rune(0x1F310))
 )
 
 func Printf(format string, a ...interface{}) {


### PR DESCRIPTION
# Description
- Support for enterprise-demo profile
Run `KUBESLICE_IMAGE_PULL_PASSWORD=xxx_xxxxx_xxxxxxx kubeslice-cli install -p enterprise-demo` to install enterprise components.
- Support for dynamic types in custom values
- Support for Prometheus chart installation
- Minor bugfixes

Fixes #

## How Has This Been Tested?

- [x] Manual Testing
- [x] Test case B


## Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] Does this PR requires documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code.
* [x] I have commented my code, particularly in hard-to-understand areas.
* [x] I have tested it for all user roles.
* [ ] I have added all the required unit test cases.

## Does this PR introduce a breaking change?
<!--
If NO, leave the release-note block blank.
If YES, a release note is required:
Enter your extended release note in the block below. If the PR requires additional manual action from users switching to the new version, include the string "action-required".
-->

```release-note

```

