### PR TITLE
Release 0.5.1

### DIFF
--- a/cmd/install.go
+++ b/cmd/install.go
@@ -30,19 +30,22 @@ var installCmd = &cobra.Command{
 		if profile != "" {
 			switch profile {
 			case pkg.ProfileFullDemo:
+				skipSteps = append(skipSteps, "prometheus")
 			case pkg.ProfileMinimalDemo:
+				skipSteps = append(skipSteps, "prometheus")
+			case pkg.ProfileEntDemo:
 			default:
-				util.Fatalf("%v Unknown profile: %s. Possible values %s", util.Cross, profile, []string{pkg.ProfileFullDemo, pkg.ProfileMinimalDemo})
+				util.Fatalf("%v Unknown profile: %s. Possible values %s", util.Cross, profile, []string{pkg.ProfileFullDemo, pkg.ProfileMinimalDemo, pkg.ProfileEntDemo})
 			}
-			pkg.ReadAndValidateConfiguration("")
-			pkg.ApplicationConfiguration.Configuration.ClusterConfiguration.Profile = profile
+			pkg.ReadAndValidateConfiguration("", profile)
 		} else {
-			pkg.ReadAndValidateConfiguration(Config)
+			pkg.ReadAndValidateConfiguration(Config, "")
 		}
 		// Default behaviour is not ot install cert-manager
 		if !withCertManager {
 			skipSteps = append(skipSteps, "cert-manager")
 		}
+
 		stepsToSkipMap := mapFromSlice(skipSteps)
 		pkg.Install(stepsToSkipMap)
 	},
@@ -61,6 +64,16 @@ Supported values:
 		Sets up 3 Kind Clusters, including 1 KubeSlice Controller and 2 KubeSlice Workers. 
 		Generates the KubernetesManifests for user to manually apply, and verify 
 		the functionality
+	- enterprise-demo:
+		Showcases the KubeSlice Enterprise functionality by spawning
+		3 Kind Clusters, including 1 KubeSlice Controller and 2 KubeSlice Workers, 
+		installing the enterprise charts for Controller and Worker with KubeSlice Manager (UI),
+		and installing iPerf application to generate network traffic. 
+		Ensure that the imagePullSecrets (username and password) are set as environment variables.
+
+		KUBESLICE_IMAGE_PULL_USERNAME : optional : Default 'aveshaenterprise'
+		KUBESLICE_IMAGE_PULL_PASSWORD : required
+
 Cannot be used with --config flag.`)
 	installCmd.Flags().StringSliceVarP(&skipSteps, "skip", "s", []string{}, `Skips the installation steps (comma-seperated). 
 Supported values:
@@ -70,8 +83,8 @@ Supported values:
 	- worker-registration: Skips the registration of KubeSlice Workers on the Controller
 	- worker: Skips the installation of KubeSlice Worker
 	- demo: Skips the installation of additional example applications
-	- ui: Skips the installtion of enterprise UI components (Kubeslice-Manager)`)
-	// TODO: update the controller version after release
+	- ui: Skips the installtion of enterprise UI components (Kubeslice-Manager)
+	- prometheus: Skips the installation of prometheus`)
 	installCmd.Flags().BoolVarP(&withCertManager, "with-cert-manager", "", false, `Installs Cert-Manager for kubeslice controller (for versions < 0.7.0)`)
 
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -22,6 +22,7 @@ KubeSlice functionality`,
 		cmd.Help()
 	},
 }
+var RootCmd = rootCmd
 
 func Execute() {
 	rootCmd.PersistentFlags().StringVarP(&Config, "config", "c", "", `<path-to-topology-configuration-yaml-file>

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -8,7 +8,7 @@ import (
 	// "github.com/spf13/cobra/doc"
 )
 
-var version = "0.5.0"
+var version = "0.5.1"
 var rootCmd = &cobra.Command{
 	Use:     "kubeslice-cli",
 	Version: version,

--- a/cmd/uninstall.go
+++ b/cmd/uninstall.go
@@ -21,7 +21,7 @@ var uninstallCmd = &cobra.Command{
 	Short:   "Performs cleanup of Kubeslice components.",
 	Args:    cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
-		pkg.ReadAndValidateConfiguration(Config)
+		pkg.ReadAndValidateConfiguration(Config, "")
 		// if --all flag is passed, other flags should not be allowed
 		if uninstallAll && uninstallUI {
 			cmd.Help()

--- a/doc/kubeslice-cli_install.md
+++ b/doc/kubeslice-cli_install.md
@@ -1,4 +1,4 @@
-## ## kubeslice-cli install
+## kubeslice-cli install
 
 Installs workloads to run KubeSlice
 
@@ -27,6 +27,16 @@ kubeslice-cli install [flags]
                             		Sets up 3 Kind Clusters, including 1 KubeSlice Controller and 2 KubeSlice Workers. 
                             		Generates the KubernetesManifests for user to manually apply, and verify 
                             		the functionality
+                            	- enterprise-demo:
+                            		Showcases the KubeSlice Enterprise functionality by spawning
+                            		3 Kind Clusters, including 1 KubeSlice Controller and 2 KubeSlice Workers, 
+                            		installing the enterprise charts for Controller and Worker with KubeSlice Manager (UI),
+                            		and installing iPerf application to generate network traffic. 
+                            		Ensure that the imagePullSecrets (username and password) are set as environment variables.
+                            
+                            		KUBESLICE_IMAGE_PULL_USERNAME : optional : Default 'aveshaenterprise'
+                            		KUBESLICE_IMAGE_PULL_PASSWORD : required
+                            
                             Cannot be used with --config flag.
   -s, --skip strings        Skips the installation steps (comma-seperated). 
                             Supported values:
@@ -37,6 +47,7 @@ kubeslice-cli install [flags]
                             	- worker: Skips the installation of KubeSlice Worker
                             	- demo: Skips the installation of additional example applications
                             	- ui: Skips the installtion of enterprise UI components (Kubeslice-Manager)
+                            	- prometheus: Skips the installation of prometheus
       --with-cert-manager   Installs Cert-Manager for kubeslice controller (for versions < 0.7.0)
 ```
 
@@ -51,5 +62,3 @@ kubeslice-cli install [flags]
 ### SEE ALSO
 
 * [kubeslice-cli](kubeslice-cli.md)	 - kubeslice-cli - a simple CLI for KubeSlice Operations
-
-

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.17
 require (
 	github.com/go-yaml/yaml v2.1.0+incompatible
 	github.com/spf13/cobra v1.6.1
+	gopkg.in/yaml.v2 v2.4.0
 	sigs.k8s.io/yaml v1.2.0
 )
 
@@ -14,7 +15,6 @@ require (
 	github.com/tidwall/gjson v1.14.2 // indirect
 	github.com/tidwall/match v1.1.1 // indirect
 	github.com/tidwall/pretty v1.2.0 // indirect
-	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 

--- a/pkg/internal/bootstrap-configuration.go
+++ b/pkg/internal/bootstrap-configuration.go
@@ -17,6 +17,7 @@ type HelmChartConfiguration struct {
 	ControllerChart  HelmChart        `yaml:"controller_chart"`
 	WorkerChart      HelmChart        `yaml:"worker_chart"`
 	UIChart          HelmChart        `yaml:"ui_chart"`
+	PrometheusChart  HelmChart        `yaml:"prometheus_chart"`
 	HelmUsername     string           `yaml:"helm_username"`
 	HelmPassword     string           `yaml:"helm_password"`
 	ImagePullSecret  ImagePullSecrets `yaml:"image_pull_secret"`
@@ -26,7 +27,7 @@ type HelmChart struct {
 	ChartName string `yaml:"chart_name"`
 	Version   string `yaml:"version"`
 	// Values to be passed as --set arguments to helm install
-	Values map[string]string `yaml:"values"`
+	Values map[string]interface{} `yaml:"values"`
 }
 
 type KubeSliceConfiguration struct {

--- a/pkg/internal/cluster-manifests.go
+++ b/pkg/internal/cluster-manifests.go
@@ -18,10 +18,29 @@ metadata:
   name: %s 
   namespace: %s
 spec:
-  networkInterface: eth0
+  clusterProperty: %s
 ---
 
 `
+const regionTemplate1 = `
+    geoLocation:
+      cloudProvider: GCP
+      cloudRegion: custom
+      latitude: "36.7783"
+      longitude: "-119.4179"
+`
+const regionTemplate2 = `
+    geoLocation:
+      cloudProvider: DATACENTER
+      cloudRegion: custom
+      latitude: "40.6976633"
+      longitude: "-74.1201054"
+`
+
+var regionTemplates = map[string]string{
+	"ks-w-1": regionTemplate1,
+	"ks-w-2": regionTemplate2,
+}
 
 func RegisterWorkerClusters(ApplicationConfiguration *ConfigurationSpecs, cliOptions *CliOptionsStruct) {
 	util.Printf("\nRegistering Worker Clusters with Project...")
@@ -51,11 +70,15 @@ func RegisterWorkerClusters(ApplicationConfiguration *ConfigurationSpecs, cliOpt
 
 func generateClusterRegistrationManifest(ApplicationConfiguration *ConfigurationSpecs, filename string, namespace string) {
 	var clusterRegistrationContent = ""
+	var regionTemplate = "{}"
 	if namespace == "" {
 		namespace = "kubeslice-" + ApplicationConfiguration.Configuration.KubeSliceConfiguration.ProjectName
 	}
 	for _, cluster := range ApplicationConfiguration.Configuration.ClusterConfiguration.WorkerClusters {
-		clusterRegistrationContent = clusterRegistrationContent + fmt.Sprintf(clusterRegistrationTemplate, cluster.Name, namespace)
+		if ApplicationConfiguration.Configuration.ClusterConfiguration.Profile == ProfileEntDemo {
+			regionTemplate = regionTemplates[cluster.Name]
+		}
+		clusterRegistrationContent = clusterRegistrationContent + fmt.Sprintf(clusterRegistrationTemplate, cluster.Name, namespace, regionTemplate)
 	}
 	util.DumpFile(clusterRegistrationContent, filename)
 }

--- a/pkg/internal/constants.go
+++ b/pkg/internal/constants.go
@@ -15,6 +15,7 @@ const (
 	Worker_Component              = "worker"
 	Demo_Component                = "demo"
 	CertManager_Component         = "cert-manager"
+	Prometheus_Component          = "prometheus"
 	SecretObject                  = "secrets"
 	OutputFormatYaml              = "yaml"
 	OutputFormatJson              = "json"

--- a/pkg/internal/project-manifest.go
+++ b/pkg/internal/project-manifest.go
@@ -37,7 +37,7 @@ func CreateKubeSliceProject(ApplicationConfiguration *ConfigurationSpecs, cliOpt
 		ApplyKubectlManifest(kubesliceDirectory+"/"+projectFileName, KUBESLICE_CONTROLLER_NAMESPACE, &ApplicationConfiguration.Configuration.ClusterConfiguration.ControllerCluster)
 	}
 	util.Printf("%s Applied %s", util.Tick, projectFileName)
-	time.Sleep(200 * time.Millisecond)
+	time.Sleep(3 * time.Second)
 	util.Printf("Created KubeSlice Project.")
 }
 

--- a/pkg/internal/prometheus.go
+++ b/pkg/internal/prometheus.go
@@ -1,0 +1,69 @@
+package internal
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/kubeslice/kubeslice-cli/util"
+)
+
+const (
+	PrometheusValuesFileName = "helm-values-Prometheus.yaml"
+	PrometheusNamespace      = "monitoring"
+)
+
+func InstallPrometheus(ApplicationConfiguration *ConfigurationSpecs) {
+	util.Printf("\nInstalling Prometheus...")
+
+	wc := ApplicationConfiguration.Configuration.ClusterConfiguration.WorkerClusters
+	cc := ApplicationConfiguration.Configuration.ClusterConfiguration.ControllerCluster
+	hc := ApplicationConfiguration.Configuration.HelmChartConfiguration
+	generatePrometheusValuesFile(hc)
+	util.Printf("%s Generated Helm Values file for Prometheus Installation %s", util.Tick, PrometheusValuesFileName)
+	time.Sleep(200 * time.Millisecond)
+	installPrometheus(wc, &cc, hc, PrometheusValuesFileName)
+	util.Printf("%s Successfully installed Prometheus on Worker clusters.", util.Tick)
+	time.Sleep(200 * time.Millisecond)
+	util.Printf("%s Setting Prometheus endpoint in cluster objects...", util.Wait)
+	projectNamespce := fmt.Sprintf("kubeslice-%s", ApplicationConfiguration.Configuration.KubeSliceConfiguration.ProjectName)
+	patchClusterObjectInControllerCluster(wc, &cc, projectNamespce)
+}
+
+func patchClusterObjectInControllerCluster(wc []Cluster, cc *Cluster, projectNS string) {
+	for _, cluster := range wc {
+		// Patch cluster object in controller cluster
+		err := util.RunCommand("kubectl", "--context", cc.ContextName, "--kubeconfig", cc.KubeConfigPath, "patch", ClusterObject, cluster.Name, "-n", projectNS, "--type", "merge", "-p", fmt.Sprintf("{\"spec\":{\"clusterProperty\":{\"telemetry\":{\"enabled\":true,\"endpoint\":\"http://%s:32700\",\"telemetryProvider\":\"prometheus\"}}}}", cluster.NodeIP))
+		if err != nil {
+			log.Fatalf("Process failed %v", err)
+		}
+		util.Printf("%s Successfully set prometheus endpoint in %s", util.Tick, cluster.Name)
+	}
+}
+
+func generatePrometheusValuesFile(hcConfig HelmChartConfiguration) {
+	err := generateValuesFile(kubesliceDirectory+"/"+PrometheusValuesFileName, &hcConfig.PrometheusChart, "")
+	if err != nil {
+		log.Fatalf("%s %s", util.Cross, err)
+	}
+}
+
+func installPrometheus(clusters []Cluster, cc *Cluster, hc HelmChartConfiguration, filename string) {
+	for _, cluster := range clusters {
+		args := make([]string, 0)
+		args = append(args, "--kube-context", cluster.ContextName, "--kubeconfig", cluster.KubeConfigPath, "upgrade", "-i", hc.PrometheusChart.ChartName, fmt.Sprintf("%s/%s", hc.RepoAlias, hc.PrometheusChart.ChartName), "--namespace", PrometheusNamespace, "--create-namespace", "-f", kubesliceDirectory+"/"+filename)
+		if hc.ControllerChart.Version != "" {
+			args = append(args, "--version", hc.PrometheusChart.Version)
+		}
+		err := util.RunCommand("helm", args...)
+		if err != nil {
+			log.Fatalf("Process failed %v", err)
+		}
+		util.Printf("%s Successfully installed helm chart %s/%s on cluster %s", util.Tick, hc.RepoAlias, hc.PrometheusChart.ChartName, cluster.Name)
+		time.Sleep(200 * time.Millisecond)
+		util.Printf("%s Waiting for Prometheus Pods to be Healthy...", util.Wait)
+		PodVerification("Waiting for Prometheus Pods to be Healthy", cluster, PrometheusNamespace)
+		// Patch cluster object in controller cluster
+	}
+
+}

--- a/pkg/ui.go
+++ b/pkg/ui.go
@@ -3,5 +3,5 @@ package pkg
 import "github.com/kubeslice/kubeslice-cli/pkg/internal"
 
 func GetUIEndpoint() {
-	internal.GetUIEndpoint(CliOptions.Cluster)
+	internal.GetUIEndpoint(CliOptions.Cluster, ApplicationConfiguration.Configuration.ClusterConfiguration.Profile)
 }

--- a/samples/template.yaml
+++ b/samples/template.yaml
@@ -50,6 +50,10 @@ configuration:
       chart_name: #{The name of the UI/Enterprise Chart}
       version: #{The version of the chart to use. Leave blank for latest version}
       values: #(Values to be passed as --set arguments to helm install)
+    prometheus_chart:
+      chart_name: #{The name of the Prometheus Chart}
+      version: #{The version of the chart to use. Leave blank for latest version}
+      values: #(Values to be passed as --set arguments to helm install)
     helm_username: #{Helm Username if the repo is private}
     helm_password: #{Helm Password if the repo is private}
     image_pull_secret: #{The image pull secrets. Optional for OpenSource, required for enterprise}

--- a/util/print-util.go
+++ b/util/print-util.go
@@ -11,6 +11,8 @@ const (
 	Wait  = string(rune(0x267B))
 	Run   = string(rune(0x1F3C3))
 	Warn  = string(rune(0x26A0))
+	Lock  = string(rune(0x1F512))
+	Globe = string(rune(0x1F310))
 )
 
 func Printf(format string, a ...interface{}) {


### PR DESCRIPTION
# Description
- Support for enterprise-demo profile
Run `KUBESLICE_IMAGE_PULL_PASSWORD=xxx_xxxxx_xxxxxxx kubeslice-cli install -p enterprise-demo` to install enterprise components.
- Support for dynamic types in custom values
- Support for Prometheus chart installation
- Minor bugfixes and refactors

Fixes #

## How Has This Been Tested?

- [x] Manual Testing
- [x] Test case B


## Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] Does this PR requires documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code.
* [x] I have commented my code, particularly in hard-to-understand areas.
* [x] I have tested it for all user roles.
* [ ] I have added all the required unit test cases.

## Does this PR introduce a breaking change?
<!--
If NO, leave the release-note block blank.
If YES, a release note is required:
Enter your extended release note in the block below. If the PR requires additional manual action from users switching to the new version, include the string "action-required".
-->

```release-note

```

