### PR TITLE
feat(): add Bookinfo demo deployment to enterprise demo flow

### DIFF
--- a/pkg/slicectl.go
+++ b/pkg/slicectl.go
@@ -57,6 +57,8 @@ func entDemo() {
 	util.Printf("%s Waiting for configuration propagation", util.Wait)
 	time.Sleep(20 * time.Second)
 	internal.RolloutRestartIPerf(ApplicationConfiguration)
+	// Deploy Bookinfo demo as part of enterprise demo
+	internal.DeployBookinfoDemo(ApplicationConfiguration)
 	internal.PrintNextSteps(true, ApplicationConfiguration)
 }
 


### PR DESCRIPTION
# Description
This PR adds support for deploying the Bookinfo demo application as part of the enterprise demo (entDemo()) flow. When the enterprise demo is set up, a minimal Bookinfo application is automatically deployed to the first worker cluster, providing users with a more realistic microservices example in addition to the existing iPerf demo.
No new files were created; all logic and manifests are included in existing files.

Fixes #76

## How Has This Been Tested?
- Ran the enterprise demo flow and verified that the Bookinfo application was deployed to the first worker cluster.
- Confirmed that the Bookinfo productpage service is running in the bookinfo namespace and accessible on port 9080.
- Verified that the user receives a message after deployment with instructions to access the service.

test-cases
- [x] Bookinfo manifest is created and applied during entDemo()
- [x] Bookinfo productpage service is running in the correct namespace
- [x] User receives deployment confirmation message

## Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR requires documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code.
* [x] I have commented my code, particularly in hard-to-understand areas.
* [x] I have tested it for all user roles.
* [ ] I have added all the required unit test cases.

## Does this PR introduce a breaking change?
<!--
If NO, leave the release-note block blank.
If YES, a release note is required:
Enter your extended release note in the block below. If the PR requires additional manual action from users switching to the new version, include the string "action-required".
-->

```release-note

```

