### PR TITLE
typo fix and error handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONEY: build
+.PHONY: build
 build:
 	GOOS=windows GOARCH=amd64 go build -o bin/kubeslice-cli-windows-amd64.exe main.go
 	GOOS=linux GOARCH=amd64 go build -o bin/kubeslice-cli-linux-amd64 main.go

--- a/util/executables.go
+++ b/util/executables.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"os"
 	"os/exec"
@@ -20,7 +21,7 @@ func RunCommand(cli string, arg ...string) error {
 	var outB, errB bytes.Buffer
 	err := RunCommandCustomIO(cli, &outB, &errB, false, arg...)
 	if err != nil {
-		Printf("%s Failed to run command\nOutput: %s\nError: %s %v", Cross, outB.String(), errB.String(), err)
+		Printf("%s Failed to run command: %s %v\nOutput: %s\nError: %s\nSuggestion: Please check if the command and its arguments are correct, and ensure all dependencies are installed.", Cross, cli, arg, outB.String(), errB.String())
 	}
 	return err
 }
@@ -39,11 +40,20 @@ func RunCommandOnStdIO(cli string, arg ...string) error {
 }
 
 func RunCommandCustomIO(cli string, stdout, stderr io.Writer, suppressPrint bool, arg ...string) error {
-	cmd := exec.Command(ExecutablePaths[cli], arg...)
+	cmdPath, ok := ExecutablePaths[cli]
+	if !ok {
+		Printf("%s Executable '%s' not found in configured paths. Please check your installation.", Cross, cli)
+		return fmt.Errorf("executable '%s' not found", cli)
+	}
+	cmd := exec.Command(cmdPath, arg...)
 	if !suppressPrint {
 		Printf("%s Running command: %s", Run, cmd.String())
 	}
 	cmd.Stdout = stdout
 	cmd.Stderr = stderr
-	return cmd.Run()
+	err := cmd.Run()
+	if err != nil && !suppressPrint {
+		Printf("%s Command failed: %s\nSuggestion: Verify the command syntax and your environment setup.", Cross, cmd.String())
+	}
+	return err
 }


### PR DESCRIPTION
resolved issue: #80 

- feat() - better error handling for better user experience.
- fix() - Typo fixed.


# Description
The typo in the Makefile has been corrected from .PHONEY to .PHONY.
Error handling in util/executables.go has been improved:
Error messages now include the command context, output, and actionable suggestions for the user.
If an executable is missing, a clear message is shown.
When a command fails, the user is prompted to check command syntax and environment setup.

## How Has This Been Tested?
Manual Testing 
