### PR TITLE
feat: Add comprehensive unit tests and refactor for testability in UI and endpoint logic

### DIFF
--- a/pkg/internal/enterprise.go
+++ b/pkg/internal/enterprise.go
@@ -24,6 +24,9 @@ kubeslice:
       type: %s
 `
 
+var runCommandCustomIO = util.RunCommandCustomIO
+var getNodeIPFunc = getNodeIP
+
 func InstallKubeSliceUI(ApplicationConfiguration *ConfigurationSpecs) {
 	util.Printf("\nInstalling KubeSlice Manager...")
 	if ApplicationConfiguration.Configuration.HelmChartConfiguration.UIChart.ChartName == "" {
@@ -112,7 +115,7 @@ func GetUIEndpoint(cc *Cluster, profile string) string {
 	ep := ""
 
 	var outB, errB bytes.Buffer
-	err := util.RunCommandCustomIO("kubectl", &outB, &errB, true, "--context="+cc.ContextName, "--kubeconfig="+cc.KubeConfigPath, "get", "services", "kubeslice-ui-proxy", "-n", KUBESLICE_CONTROLLER_NAMESPACE, "-o", "jsonpath='{.spec}'")
+	err := runCommandCustomIO("kubectl", &outB, &errB, true, "--context="+cc.ContextName, "--kubeconfig="+cc.KubeConfigPath, "get", "services", "kubeslice-ui-proxy", "-n", KUBESLICE_CONTROLLER_NAMESPACE, "-o", "jsonpath='{.spec}'")
 	if err == nil {
 		jsonMap := make(map[string]interface{})
 		err = json.Unmarshal(outB.Bytes()[1:len(outB.Bytes())-1], &jsonMap)
@@ -129,7 +132,7 @@ func GetUIEndpoint(cc *Cluster, profile string) string {
 					portMap := port.(map[string]interface{})
 					if portMap["name"] == "http" { // Assuming that http is the name of the port that you want to use
 						nodePort := int(portMap["nodePort"].(float64))
-						nodeIP, err := getNodeIP(cc)
+						nodeIP, err := getNodeIPFunc(cc)
 						if err == nil {
 							ep = fmt.Sprintf("https://%s:%d", strings.Trim(nodeIP, "'"), nodePort)
 						} else {

--- a/pkg/internal/enterprise_test.go
+++ b/pkg/internal/enterprise_test.go
@@ -1,0 +1,129 @@
+package internal
+
+import (
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/kubeslice/kubeslice-cli/util"
+)
+
+// Mock getNodeIP to return dummy IP
+func mockGetNodeIP(_ *Cluster) (string, error) {
+	return "192.168.1.100", nil
+}
+
+func TestGetUIEndpoint_NodePort(t *testing.T) {
+	runCalled := false
+
+	// Mock kubectl output for NodePort
+	nodePortJSON := `{
+		"type": "NodePort",
+		"ports": [{
+			"name": "http",
+			"nodePort": 30080
+		}]
+	}`
+
+	runCommandCustomIO = func(name string, stdout, stderr io.Writer, _ bool, args ...string) error {
+		runCalled = true
+		stdout.Write([]byte("'" + nodePortJSON + "'")) // wrap in quotes to simulate jsonpath output
+		return nil
+	}
+	getNodeIPFunc = mockGetNodeIP
+	defer func() {
+		runCommandCustomIO = util.RunCommandCustomIO
+		getNodeIPFunc = getNodeIP
+	}()
+
+	cluster := &Cluster{
+		ContextName:    "mock-context",
+		KubeConfigPath: "/fake/config",
+	}
+	endpoint := GetUIEndpoint(cluster, "some-profile")
+
+	expected := "https://192.168.1.100:30080"
+	if endpoint != expected {
+		t.Errorf("Expected endpoint %q, got %q", expected, endpoint)
+	}
+	if !runCalled {
+		t.Error("Expected RunCommandCustomIO to be called")
+	}
+}
+
+// Mocks a LoadBalancer service and checks the endpoint.
+func TestGetUIEndpoint_LoadBalancer(t *testing.T) {
+	runCalled := false
+
+	// Mock output for LoadBalancer
+	loadBalancerJSON := `{
+		"type": "LoadBalancer",
+		"externalIPs": ["1.2.3.4"],
+		"ports": [{
+			"name": "http",
+			"port": 443
+		}]
+	}`
+
+	runCommandCustomIO = func(name string, stdout, stderr io.Writer, _ bool, args ...string) error {
+		runCalled = true
+		stdout.Write([]byte("'" + loadBalancerJSON + "'"))
+		return nil
+	}
+	defer func() {
+		runCommandCustomIO = util.RunCommandCustomIO
+	}()
+
+	cluster := &Cluster{
+		ContextName:    "mock-context",
+		KubeConfigPath: "/fake/config",
+	}
+	endpoint := GetUIEndpoint(cluster, "some-profile")
+
+	expected := "https://1.2.3.4:443"
+	if endpoint != expected {
+		t.Errorf("Expected endpoint %q, got %q", expected, endpoint)
+	}
+	if !runCalled {
+		t.Error("Expected RunCommandCustomIO to be called")
+	}
+}
+
+// Mocks invalid JSON output and checks that the function returns an empty string
+func TestGetUIEndpoint_InvalidJSON(t *testing.T) {
+	runCommandCustomIO = func(name string, stdout, stderr io.Writer, _ bool, args ...string) error {
+		stdout.Write([]byte("'not-a-json'"))
+		return nil
+	}
+	defer func() {
+		runCommandCustomIO = util.RunCommandCustomIO
+	}()
+
+	cluster := &Cluster{
+		ContextName:    "mock-context",
+		KubeConfigPath: "/fake/config",
+	}
+	endpoint := GetUIEndpoint(cluster, "profile")
+	if endpoint != "" {
+		t.Errorf("Expected empty endpoint on invalid JSON, got %q", endpoint)
+	}
+}
+
+// Mocks a command failure and checks that the function returns an empty string
+func TestGetUIEndpoint_CommandFailure(t *testing.T) {
+	runCommandCustomIO = func(name string, stdout, stderr io.Writer, _ bool, args ...string) error {
+		return errors.New("kubectl failed")
+	}
+	defer func() {
+		runCommandCustomIO = util.RunCommandCustomIO
+	}()
+
+	cluster := &Cluster{
+		ContextName:    "mock-context",
+		KubeConfigPath: "/fake/config",
+	}
+	endpoint := GetUIEndpoint(cluster, "profile")
+	if endpoint != "" {
+		t.Errorf("Expected empty endpoint on command failure, got %q", endpoint)
+	}
+}

--- a/pkg/ui.go
+++ b/pkg/ui.go
@@ -2,6 +2,8 @@ package pkg
 
 import "github.com/kubeslice/kubeslice-cli/pkg/internal"
 
+var getUIEndpointFunc = internal.GetUIEndpoint
+
 func GetUIEndpoint() {
-	internal.GetUIEndpoint(CliOptions.Cluster, ApplicationConfiguration.Configuration.ClusterConfiguration.Profile)
+	getUIEndpointFunc(CliOptions.Cluster, ApplicationConfiguration.Configuration.ClusterConfiguration.Profile)
 }

--- a/pkg/ui_test.go
+++ b/pkg/ui_test.go
@@ -1,0 +1,49 @@
+package pkg
+
+import (
+	"testing"
+
+	"github.com/kubeslice/kubeslice-cli/pkg/internal"
+)
+
+func TestGetUIEndpoint_WithMock(t *testing.T) {
+	// Initialize CliOptions using the helper
+	cliParams := CliParams{
+		ObjectType:   "project",
+		ObjectName:   "mock-cluster",
+		Namespace:    "test-namespace",
+		FileName:     "test-file.yaml",
+		Config:       "",
+		OutputFormat: "json",
+	}
+	SetCliOptions(cliParams)
+
+	// Initialize ApplicationConfiguration and nested fields
+	ApplicationConfiguration = &internal.ConfigurationSpecs{}
+	ApplicationConfiguration.Configuration = internal.Configuration{}
+	ApplicationConfiguration.Configuration.ClusterConfiguration = internal.ClusterConfiguration{}
+	ApplicationConfiguration.Configuration.ClusterConfiguration.Profile = "mock-profile"
+
+	called := false
+	mockFunc := func(c *internal.Cluster, profile string) string {
+		called = true
+		if c.Name != "mock-cluster" || profile != "mock-profile" {
+			t.Errorf("Unexpected values: cluster=%v, profile=%v", c.Name, profile)
+		}
+		return "https://mock-endpoint"
+	}
+
+	// Inject mock
+	getUIEndpointFunc = mockFunc
+	defer func() { getUIEndpointFunc = internal.GetUIEndpoint }() // Restore after test
+
+	// Inject mock config
+	CliOptions.Cluster = &internal.Cluster{Name: "mock-cluster"}
+	ApplicationConfiguration.Configuration.ClusterConfiguration.Profile = "mock-profile"
+
+	GetUIEndpoint()
+
+	if !called {
+		t.Error("Expected mock GetUIEndpoint to be called")
+	}
+}


### PR DESCRIPTION

## **Description**


This PR adds comprehensive unit tests for the `GetUIEndpoint` function in `pkg/ui.go` and the endpoint logic in `pkg/internal/enterprise.go`, which handle UI endpoint retrieval and service endpoint construction for the KubeSlice CLI. Both functions have been refactored to use dependency injection for improved testability.

I've refactored the functions to accept dependencies, which allowed me to mock command execution and node IP retrieval. This effort boosts test coverage to 100% for pkg/ui.go and 94.4% for GetUIEndpoint in pkg/internal/enterprise.go.

This test suite covers 5 scenarios including NodePort and LoadBalancer service types, invalid JSON handling, and command failure cases. All tests pass and existing functionality remains unchanged.


## **Testing Approach**

**UI Wrapper Function (`pkg/ui.go`)**
- Tests the wrapper function to ensure correct wiring and argument passing
- Uses dependency injection to replace the internal function with a mock
- Verifies that the mock is called with correct parameters and that the wrapper doesn't panic

**Endpoint Logic (`pkg/internal/enterprise.go` - `GetUIEndpoint`)**
- Tests the core business logic including command execution, JSON parsing, and endpoint construction
- Uses dependency injection to mock command execution and node IP retrieval
- Covers NodePort scenario: mocks NodePort service and verifies correct endpoint construction
- Covers LoadBalancer scenario: mocks LoadBalancer service and verifies correct endpoint construction  
- Covers Invalid JSON scenario: mocks invalid output and verifies graceful error handling
- Covers Command failure scenario: mocks command errors and verifies proper error handling

## **Coverage Results**

| File | Before | After |
|------|--------|-------|
| `pkg/ui.go` | 0% | 100% |
| `pkg/internal/enterprise.go` (GetUIEndpoint) | 0% | 94.4% |

## **How Has This Been Tested?**

- Test case A: UI wrapper function with dependency injection and global state setup
- Test case B: NodePort service endpoint generation and validation
- Test case C: LoadBalancer service endpoint generation and validation
- Test case D: Invalid JSON error handling and graceful degradation
- Test case E: Command failure error handling and empty endpoint return
- Verified all existing functionality still works with `go build` and `go test`

---
`pkg/internal/enterprise.go :-  @kubeslice-cli % go tool cover -func=coverage.out | grep ui.go`

<img width="1470" height="50" alt="Screenshot 2025-08-05 at 7 11 28 PM" src="https://github.com/user-attachments/assets/1f15372e-15cd-4cf2-ba1a-a7e7e872adf7" />

---

`pkg/ui.go  file :- kubeslice-cli % go tool cover -func=enterprise_coverage.out | grep enterprise.go `

<img width="838" height="157" alt="Screenshot 2025-08-05 at 7 17 14 PM" src="https://github.com/user-attachments/assets/8a783dd4-8f7b-4f86-9078-ad9327f2d8e7" />


## **Does this PR introduce a breaking change?**

No breaking changes. Functions maintain the same interface and behavior while being made more testable through dependency injection.

---

PTAL @priyupadhyay  @narmidm  @Rahul-D78 @gourishkb 
