### PR TITLE
feat(cli): Added Slice Health Status Functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ KubeSlice functionality
   edit        Edit Kubeslice resources.
   get         Get Kubeslice resources.
   install     Installs workloads to run KubeSlice
+  register    Register a Kubeslice worker cluster.
+  show-health Show health status of KubeSlice resources.
   uninstall   Performs cleanup of Kubeslice components.
   help        Help about any command
 
@@ -57,6 +59,7 @@ KubeSlice functionality
 * [kubeslice-cli get](doc/kubeslice-cli_get.md)	 - Get Kubeslice resources.
 * [kubeslice-cli install](doc/kubeslice-cli_install.md)	 - Installs workloads to run KubeSlice.
 * [kubeslice-cli register](doc/kubeslice-cli_register.md)	 - Register a Kubeslice worker cluster.
+* [kubeslice-cli show-health](doc/kubeslice-cli_show-health.md)	 - Show health status of KubeSlice resources.
 * [kubeslice-cli uninstall](doc/kubeslice-cli_uninstall.md)	 - Performs cleanup of Kubeslice components.
 
 

--- a/cmd/show-health.go
+++ b/cmd/show-health.go
@@ -1,0 +1,48 @@
+package cmd
+
+import (
+	"github.com/kubeslice/kubeslice-cli/pkg"
+	"github.com/kubeslice/kubeslice-cli/util"
+	"github.com/spf13/cobra"
+)
+
+var showHealthCmd = &cobra.Command{
+	Use:     "show-health",
+	Aliases: []string{"health"},
+	Short:   "Show health status of KubeSlice resources.",
+	Args:    cobra.RangeArgs(1, 2),
+	Run: func(cmd *cobra.Command, args []string) {
+		var objectName string
+		ns, _ := cmd.Flags().GetString("namespace")
+		if ns == "" {
+			util.Fatalf("Namespace is required")
+		}
+		all, _ := cmd.Flags().GetBool("all")
+		
+		if len(args) > 1 {
+			objectName = args[1]
+		}
+
+		pkg.SetCliOptions(pkg.CliParams{Config: Config, Namespace: ns, ObjectName: objectName, ObjectType: args[0], OutputFormat: outputFormat})
+		switch args[0] {
+		case "slice":
+			if all {
+				pkg.ShowAllSliceHealth()
+			} else {
+				if objectName == "" {
+					util.Fatalf("Slice name is required when not using --all flag")
+				}
+				pkg.ShowSliceHealth()
+			}
+		default:
+			util.Fatalf("Invalid object type. Supported types: slice")
+		}
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(showHealthCmd)
+	showHealthCmd.Flags().StringP("namespace", "n", "", "namespace")
+	showHealthCmd.Flags().BoolP("all", "A", false, "show health for all slices")
+	showHealthCmd.Flags().StringVarP(&outputFormat, "output", "o", "", "supported values json, yaml")
+} 

--- a/doc/kubeslice-cli_show-health.md
+++ b/doc/kubeslice-cli_show-health.md
@@ -1,0 +1,79 @@
+# kubeslice-cli show-health
+
+Show health status of KubeSlice resources.
+
+## Synopsis
+
+The `show-health` command allows you to view the health status of KubeSlice slices. It provides detailed information about the health and status of slice configurations.
+
+```bash
+kubeslice-cli show-health [resource-type] [resource-name] [flags]
+```
+
+## Examples
+
+### Show health for a specific slice
+```bash
+kubeslice-cli show-health slice my-slice -n kubeslice-demo
+```
+
+### Show health for all slices
+```bash
+kubeslice-cli show-health slice -A -n kubeslice-demo
+```
+
+### Show health with JSON output
+```bash
+kubeslice-cli show-health slice my-slice -n kubeslice-demo -o json
+```
+
+### Show health with YAML output
+```bash
+kubeslice-cli show-health slice my-slice -n kubeslice-demo -o yaml
+```
+
+## Available Resource Types
+
+- `slice` - Show health status of KubeSlice slice configurations
+
+## Flags
+
+- `-A, --all` - Show health for all slices (when used with slice resource type)
+- `-n, --namespace string` - Namespace where the slice is located (required)
+- `-o, --output string` - Output format (json, yaml)
+
+## Global Flags
+
+- `-c, --config string` - Path to topology configuration YAML file
+
+## Health Status Information
+
+The command displays the following health information:
+
+- **Status**: Ready/Not Ready/Unknown
+- **Conditions**: Available health conditions
+- **Slice Subnet**: Configuration status
+- **Clusters**: Connection status
+- **Raw Output**: Complete JSON/YAML output from kubectl
+
+## Usage Notes
+
+1. The `--namespace` flag is required for all show-health operations
+2. When using `--all` flag, you don't need to specify a resource name
+3. The command uses kubectl to fetch slice configuration data
+4. Health status is determined by parsing the slice configuration status
+5. Raw output is always displayed for debugging purposes
+
+## Error Handling
+
+- If the slice doesn't exist, an error will be displayed
+- If the namespace doesn't exist, an error will be displayed
+- If kubectl is not available, an error will be displayed
+- Network connectivity issues will be reported
+
+## Related Commands
+
+- `kubeslice-cli get slice` - Get slice configuration details
+- `kubeslice-cli describe slice` - Describe slice configuration
+- `kubeslice-cli create slice` - Create a new slice
+- `kubeslice-cli delete slice` - Delete a slice 

--- a/pkg/slice.go
+++ b/pkg/slice.go
@@ -28,3 +28,11 @@ func EditSliceConfig() {
 func DescribeSliceConfig() {
 	internal.DescribeSliceConfig(CliOptions.ObjectName, CliOptions.Namespace, CliOptions.Cluster)
 }
+
+func ShowSliceHealth() {
+	internal.ShowSliceHealth(CliOptions.ObjectName, CliOptions.Namespace, CliOptions.Cluster)
+}
+
+func ShowAllSliceHealth() {
+	internal.ShowAllSliceHealth(CliOptions.Namespace, CliOptions.Cluster)
+}


### PR DESCRIPTION
fix #66 
#  Add show-health command to kubeslice-cli

## Summary
Implements `kubeslice-cli show-health slice <SLICE-NAME>` command to display KubeSlice slice health status.

## Changes
- Added `cmd/show-health.go` - Main command implementation with Cobra
- Enhanced `pkg/slice.go` - Added `ShowSliceHealth()` and `ShowAllSliceHealth()` functions  
- Updated `pkg/internal/slice-config.go` - Added JSON parsing and health status display
- Created `doc/kubeslice-cli_show-health.md` - Complete documentation
- Updated `README.md` - Added new command to available commands list

## Testing
 Tested on GKE cluster with KubeSlice 1.4.0 - Command successfully connects to cluster, parses JSON output, and displays health status. All error handling scenarios tested and working correctly.

## Usage
```bash
kubeslice-cli show-health slice my-slice -n kubeslice-demo
kubeslice-cli show-health slice -A -n kubeslice-demo