### PR TITLE
test(): Added unit tests for generateImagePullSecretsValue function in helm-repo-add.go file

### DIFF
--- a/pkg/internal/helm-repo-add_test.go
+++ b/pkg/internal/helm-repo-add_test.go
@@ -1,0 +1,82 @@
+package internal
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestGenerateImagePullSecretsValue(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    ImagePullSecrets
+		expected string
+	}{
+		{
+			name: "All fields provided",
+			input: ImagePullSecrets{
+				Registry: "my-registry.com",
+				Username: "user",
+				Password: "password123",
+				Email:    "user@example.com",
+			},
+			expected: fmt.Sprintf(imagePullSecretsTemplate, "my-registry.com", "user", "password123", "email: user@example.com"),
+		},
+		{
+			name: "Default registry used when registry is empty",
+			input: ImagePullSecrets{
+				Username: "user",
+				Password: "password123",
+				Email:    "user@example.com",
+			},
+			expected: fmt.Sprintf(imagePullSecretsTemplate, "https://index.docker.io/v1/", "user", "password123", "email: user@example.com"),
+		},
+		{
+			name: "Email is optional",
+			input: ImagePullSecrets{
+				Registry: "my-registry.com",
+				Username: "user",
+				Password: "password123",
+			},
+			expected: fmt.Sprintf(imagePullSecretsTemplate, "my-registry.com", "user", "password123", ""),
+		},
+		{
+			name: "Returns empty string if username is missing",
+			input: ImagePullSecrets{
+				Password: "password123",
+			},
+			expected: "",
+		},
+		{
+			name: "Returns empty string if password is missing",
+			input: ImagePullSecrets{
+				Username: "user",
+			},
+			expected: "",
+		},
+		{
+			name:     "Returns empty string for empty input struct",
+			input:    ImagePullSecrets{},
+			expected: "",
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc // Capture range variable for Go < 1.22
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := generateImagePullSecretsValue(tc.input)
+
+			// Trim whitespace to make the comparison robust
+			gotTrimmed := strings.TrimSpace(got)
+			expectedTrimmed := strings.TrimSpace(tc.expected)
+
+			if gotTrimmed != expectedTrimmed {
+				t.Errorf("generateImagePullSecretsValue() mismatch:\nwant: %q\ngot:  %q", expectedTrimmed, gotTrimmed)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Description
This PR introduces unit tests for the `generateImagePullSecretsValue` function in the internal package. The tests cover multiple scenarios, including default registry handling, optional email fields, and validation for required fields, ensuring the imagePullSecrets YAML snippet is generated correctly and reliably.

## How Has This Been Tested?
Local Testing:
```
go test ./pkg/internal -v
go test ./pkg/internal -cover
```
**Overall Coverage Increase:** This PR increases the overall coverage by 0.9%

## Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR requires documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code.
* [x] I have commented my code, particularly in hard-to-understand areas.
* [ ] I have tested it for all user roles.
* [x] I have added all the required unit test cases.

## Does this PR introduce a breaking change?
<!--
If NO, leave the release-note block blank.
If YES, a release note is required:
Enter your extended release note in the block below. If the PR requires additional manual action from users switching to the new version, include the string "action-required".
-->

```release-note

```

